### PR TITLE
Broken writable filesystem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 .DS_Store
 libc/build/
 setup/rust/
+*.swp

--- a/filesystem/apps/editor/editor.rs
+++ b/filesystem/apps/editor/editor.rs
@@ -37,6 +37,7 @@ impl Editor {
         let mut resource = File::open(&self.url);
         resource.seek(Seek::Start(0));
         resource.write(&self.string.to_utf8().as_slice());
+        resource.flush();
     }
 
     fn draw_content(&mut self, window: &mut Window){

--- a/filesystem/apps/editor/editor.rs
+++ b/filesystem/apps/editor/editor.rs
@@ -35,6 +35,7 @@ impl Editor {
         window.title = "Editor (".to_string() + &self.url + ") Saved";
 
         let mut resource = File::open(&self.url);
+        resource.seek(Seek::Start(0));
         resource.write(&self.string.to_utf8().as_slice());
     }
 

--- a/libredox/file.rs
+++ b/libredox/file.rs
@@ -3,6 +3,13 @@ use common::vec::*;
 
 use syscall::call::*;
 
+/// File seek
+pub enum Seek {
+    Start(usize),
+    Current(isize),
+    End(isize)
+}
+
 /// A Unix-style file
 pub struct File {
     path: String,
@@ -72,16 +79,28 @@ impl File {
         }
     }
 
-    /*
     pub fn seek(&mut self, pos: Seek) -> Option<usize> {
-        Option::None
+        let (whence, offset) =
+            match pos {
+                Seek::Start(offset) => (0, offset as isize),
+                Seek::Current(offset) => (1, offset),
+                Seek::End(offset) => (2, offset),
+            };
+        unsafe {
+            if sys_lseek(self.fd, offset, whence) == 0xFFFFFFFF {
+                Option::None
+            } else {
+                // TODO
+                Option::Some(0)
+            }
+        }
     }
-    */
 
     /// Flush the io
     pub fn flush(&mut self) -> bool {
-        // TODO
-        false
+        unsafe {
+            sys_fsync(self.fd) == 0
+        }
     }
 }
 

--- a/src/drivers/disk.rs
+++ b/src/drivers/disk.rs
@@ -89,6 +89,7 @@ pub struct PRDTE {
     pub reserved: u16
 }
 
+#[derive(Copy, Clone)]
 pub struct Disk {
     base: u16,
     ctrl: u16,

--- a/src/syscall/call.rs
+++ b/src/syscall/call.rs
@@ -39,6 +39,14 @@ pub unsafe fn sys_close(fd: usize) -> usize {
     syscall(SYS_CLOSE, fd as u32, 0, 0) as usize
 }
 
+pub unsafe fn sys_lseek(fd: usize, offset: isize, whence: usize) -> usize {
+    syscall(SYS_LSEEK, fd as u32, offset as u32, whence as u32) as usize
+}
+
+pub unsafe fn sys_fsync(fd: usize) -> usize {
+    syscall(SYS_FSYNC, fd as u32, 0, 0) as usize
+}
+
 pub unsafe fn sys_time(time_ptr: *mut Duration, realtime: bool) {
     syscall(SYS_TIME, time_ptr as u32, realtime as u32, 0);
 }

--- a/src/syscall/common.rs
+++ b/src/syscall/common.rs
@@ -11,6 +11,7 @@ pub const SYS_LSEEK: u32 = 19;
 pub const SYS_FSTAT: u32 = 28;
 pub const SYS_BRK: u32 = 45;
 pub const SYS_GETTIMEOFDAY: u32 = 78;
+pub const SYS_FSYNC: u32 = 118;
 pub const SYS_YIELD: u32 = 158;
 
 //Rust Memory


### PR DESCRIPTION
I did several things:
- Implemented `File::seek` and `File::flush` in libredox/file.rs
- Implemented `sys_lseek` and `sys_fsync` in syscall/call.rs
- Implemented `do_sys_fsync` and added it as handler for `SYS_FSYNC` in syscall/handle.rs
- Revised `Editor::save` in filesystem/apps/editor/editor.rs to write and flush the file.

If you edit a file, then save with F6, then reload with F5, you will see a lovely corrupted string.