### PR TITLE
s/flush/sync/g

### DIFF
--- a/src/audio/ac97.rs
+++ b/src/audio/ac97.rs
@@ -160,7 +160,7 @@ impl Resource for AC97Resource {
         Option::None
     }
 
-    fn flush(&mut self) -> bool {
+    fn sync(&mut self) -> bool {
         false
     }
 }

--- a/src/audio/intelhda.rs
+++ b/src/audio/intelhda.rs
@@ -194,7 +194,7 @@ impl Resource for IntelHDAResource {
         Option::None
     }
 
-    fn flush(&mut self) -> bool {
+    fn sync(&mut self) -> bool {
         false
     }
 }

--- a/src/common/resource.rs
+++ b/src/common/resource.rs
@@ -39,8 +39,8 @@ pub trait Resource {
     fn write(&mut self, buf: &[u8]) -> Option<usize>;
     /// Seek
     fn seek(&mut self, pos: ResourceSeek) -> Option<usize>;
-    /// Flush the resource
-    fn flush(&mut self) -> bool;
+    /// Sync the resource
+    fn sync(&mut self) -> bool;
 
     //Helper functions
     fn read_to_end(&mut self, vec: &mut Vec<u8>) -> Option<usize> {
@@ -377,7 +377,7 @@ impl Resource for NoneResource {
         return Option::None;
     }
 
-    fn flush(&mut self) -> bool {
+    fn sync(&mut self) -> bool {
         return false;
     }
 }
@@ -453,7 +453,7 @@ impl Resource for VecResource {
         return Option::Some(self.seek);
     }
 
-    fn flush(&mut self) -> bool {
+    fn sync(&mut self) -> bool {
         return true;
     }
 }

--- a/src/network/scheme.rs
+++ b/src/network/scheme.rs
@@ -91,7 +91,7 @@ impl Resource for NetworkResource {
         Option::None
     }
 
-    fn flush(&mut self) -> bool {
+    fn sync(&mut self) -> bool {
         false
     }
 }

--- a/src/schemes/debug.rs
+++ b/src/schemes/debug.rs
@@ -58,7 +58,7 @@ impl Resource for DebugResource {
         return Option::None;
     }
 
-    fn flush(&mut self) -> bool {
+    fn sync(&mut self) -> bool {
         return true;
     }
 }

--- a/src/schemes/ethernet.rs
+++ b/src/schemes/ethernet.rs
@@ -77,8 +77,8 @@ impl Resource for EthernetResource {
         return Option::None;
     }
 
-    fn flush(&mut self) -> bool {
-        return self.network.flush();
+    fn sync(&mut self) -> bool {
+        return self.network.sync();
     }
 }
 

--- a/src/schemes/file.rs
+++ b/src/schemes/file.rs
@@ -196,7 +196,7 @@ impl Resource for FileResource {
     // TODO: Rename to sync
     // TODO: Check to make sure proper amount of bytes written. See Disk::write
     // TODO: Allow reallocation
-    fn flush(&mut self) -> bool {
+    fn sync(&mut self) -> bool {
         if self.dirty {
             let block_size: usize = 512;
 
@@ -249,7 +249,7 @@ impl Resource for FileResource {
 
 impl Drop for FileResource {
     fn drop(&mut self) {
-        self.flush();
+        self.sync();
     }
 }
 

--- a/src/schemes/ip.rs
+++ b/src/schemes/ip.rs
@@ -92,8 +92,8 @@ impl Resource for IPResource {
         return Option::None;
     }
 
-    fn flush(&mut self) -> bool {
-        return self.link.flush();
+    fn sync(&mut self) -> bool {
+        return self.link.sync();
     }
 }
 

--- a/src/schemes/tcp.rs
+++ b/src/schemes/tcp.rs
@@ -151,8 +151,8 @@ impl Resource for TCPResource {
         return Option::None;
     }
 
-    fn flush(&mut self) -> bool {
-        return self.ip.flush();
+    fn sync(&mut self) -> bool {
+        return self.ip.sync();
     }
 }
 

--- a/src/schemes/udp.rs
+++ b/src/schemes/udp.rs
@@ -93,8 +93,8 @@ impl Resource for UDPResource {
         return Option::None;
     }
 
-    fn flush(&mut self) -> bool {
-        return self.ip.flush();
+    fn sync(&mut self) -> bool {
+        return self.ip.sync();
     }
 }
 

--- a/src/syscall/handle.rs
+++ b/src/syscall/handle.rs
@@ -218,7 +218,7 @@ pub unsafe fn do_sys_fsync(fd: usize) -> usize {
                 if file.fd == fd {
                     end_no_ints(reenable);
 
-                    if file.resource.flush() {
+                    if file.resource.sync() {
                         ret = 0;
                     }
 


### PR DESCRIPTION
`Resource::flush` became `Resource::sync`