### PR TITLE
test window builds via appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,4 +7,4 @@ install:
   - git submodule update --init --recursive
 
 build_script:
-  - cmd: make all
+  - cmd: windows\make all

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,10 @@
+install:
+  - ps: Start-FileDownload 'https://static.rust-lang.org/dist/rust-nightly-i686-pc-windows-gnu.exe'
+  - rust-nightly-i686-pc-windows-gnu.exe /VERYSILENT /NORESTART /DIR="C:\Program Files (x86)\Rust"
+  - SET PATH=%PATH%;C:\Program Files (x86)\Rust\bin
+  - rustc -V
+  - cargo -V
+  - git submodule update --init --recursive
+
+build_script:
+  - cmd: make all


### PR DESCRIPTION
Looks like AppVeyor will do free builds for public repos. This PR adds in the appveyor.yml file to configure the builds and run them (it currently passes). If you want to use it you'll need to setup an AppVeyor account and connect it to the org.