### PR TITLE
Fix warnings

### DIFF
--- a/filesystem/apps/test/test.rs
+++ b/filesystem/apps/test/test.rs
@@ -5,7 +5,7 @@ extern crate alloc;
 extern crate core;
 
 use alloc::boxed::Box;
-use std::{io, fs, rand};
+use std::{io, rand};
 use core::ptr;
 
 macro_rules! readln {
@@ -13,8 +13,8 @@ macro_rules! readln {
         {
             let mut line = String::new();
             match io::stdin().read_line(&mut line) {
-                Ok(n) => Some(line.trim().to_string()),
-                Err(e) => None
+                Ok(_) => Some(line.trim().to_string()),
+                Err(_) => None
             }
         }
     };

--- a/filesystem/apps/zfs/nvstream.rs
+++ b/filesystem/apps/zfs/nvstream.rs
@@ -119,7 +119,7 @@ pub fn decode_nv_list_embedded(xdr: &mut xdr::Xdr) -> xdr::XdrResult<NvList> {
         let decoded_size = try!(xdr.decode_u32());
 
         // Check for 2 terminating zeros
-        if (encoded_size == 0 && decoded_size == 0) {
+        if encoded_size == 0 && decoded_size == 0 {
             break;
         }
 

--- a/filesystem/apps/zfs/xdr/xdr.rs
+++ b/filesystem/apps/zfs/xdr/xdr.rs
@@ -94,7 +94,7 @@ impl<T: XdrOps> Xdr for T {
                 false => 0,
                 true => 1,
             };
-        self.put_i32(b as i32)
+        self.put_i32(i)
     }
 
     fn decode_bool(&mut self) -> XdrResult<bool> {
@@ -172,7 +172,7 @@ impl<T: XdrOps> Xdr for T {
 
     fn encode_opaque(&mut self, bytes: &[u8]) -> XdrResult<()> {
         // XDR byte strings always have len%4 == 0
-        let mut crud: [u8; 4] = [0; 4];
+        let crud: [u8; 4] = [0; 4];
         let mut round_up = bytes.len()%4;
         if round_up > 0 {
             round_up = 4 - round_up;

--- a/libredox/src/ion/command.rs
+++ b/libredox/src/ion/command.rs
@@ -119,7 +119,7 @@ impl Command {
 
                 vec = Vec::new();
                 match resource.read_to_end(&mut vec) {
-                    Option::Some(size) =>
+                    Option::Some(_) =>
                         println!("{}", unsafe { String::from_utf8_unchecked(vec) }),
                     Option::None => println!("Failed to read"),
                 }

--- a/libredox/src/rt.rs
+++ b/libredox/src/rt.rs
@@ -1,4 +1,4 @@
-use syscall::{sys_debug, sys_exit};
+use syscall::sys_exit;
 
 pub fn begin_unwind(string: &'static str, file_line: &(&'static str, u32)) -> ! {
     let &(file, line) = file_line;

--- a/src/common/src/resource.rs
+++ b/src/common/src/resource.rs
@@ -118,24 +118,11 @@ impl URL {
 
     /// Return the scheme of this url
     pub fn scheme(&self) -> String {
-        let mut part_i = 0;
-        for part in self.string.split("/".to_string()) {
-            match part_i {
-                0 => {
-                    let scheme_part_i = 0;
-                    for scheme_part in part.split(":".to_string()) {
-                        match scheme_part_i {
-                            0 => return scheme_part,
-                            _ => break,
-                        }
-                        scheme_part_i += 1;
-                    }
-                }
-                _ => break,
+        if let Some(part) = self.string.split("/".to_string()).next() {
+            if let Some(scheme_part) = part.split(":".to_string()).next() {
+                return scheme_part;
             }
-            part_i += 1;
         }
-
         return String::new();
     }
 

--- a/src/drivers/src/ps2.rs
+++ b/src/drivers/src/ps2.rs
@@ -1,6 +1,5 @@
 use alloc::boxed::Box;
 
-use common::debug;
 use common::event::{KeyEvent, MouseEvent};
 
 use drivers::pio::*;

--- a/src/graphics/src/display.rs
+++ b/src/graphics/src/display.rs
@@ -263,8 +263,8 @@ impl Display {
             // Find error and error change
             let mut error = 0.0;
             // This is a bit annoying... but libcore does not have .abs() defined on f64 ;-(
-            let mut delta_error = {
-                let delta_error_signed = ((delta.y as f64) / (delta.x as f64));
+            let delta_error = {
+                let delta_error_signed = (delta.y as f64) / (delta.x as f64);
                 if delta_error_signed < 0.0 {
                     -delta_error_signed
                 } else {

--- a/src/network/src/rtl8139.rs
+++ b/src/network/src/rtl8139.rs
@@ -161,7 +161,7 @@ impl RTL8139 {
         while let Option::Some(bytes) = self.outbound.pop() {
             if let Option::Some(txd) = self.txds.get(self.txd_i) {
                 if bytes.len() < 4096 {
-                    let mut tx_status = 0;
+                    let mut tx_status;
                     loop {
                         tx_status = ind(txd.status_port);
                         if tx_status & (1 << 13) == (1 << 13) {

--- a/src/programs/src/scheme.rs
+++ b/src/programs/src/scheme.rs
@@ -8,7 +8,6 @@ use common::elf::*;
 use common::memory;
 use common::paging::Page;
 use common::resource::URL;
-use common::scheduler;
 use common::string::*;
 use common::vec::Vec;
 

--- a/src/programs/src/session.rs
+++ b/src/programs/src/session.rs
@@ -3,7 +3,7 @@ use super::executor::*;
 
 use alloc::boxed::Box;
 
-use core::{cmp, ptr, mem};
+use core::cmp;
 
 use common::event::{self, Event, EventOption, KeyEvent, MouseEvent};
 use common::resource::{NoneResource, Resource, ResourceType, URL, VecResource};

--- a/src/schemes/src/window.rs
+++ b/src/schemes/src/window.rs
@@ -143,8 +143,8 @@ impl SessionItem for WindowScheme {
             }
         }
 
-        let mut p: Point = Point::new(pointx, pointy);
-        let mut s: Size = Size::new(size_width, size_height);
+        let p: Point = Point::new(pointx, pointy);
+        let s: Size = Size::new(size_width, size_height);
 
         return box WindowResource {
             window: Window::new(p, s, title),

--- a/src/syscall/src/handle.rs
+++ b/src/syscall/src/handle.rs
@@ -211,7 +211,7 @@ pub unsafe fn do_sys_fsync(fd: usize) -> usize {
     let reenable = scheduler::start_no_ints();
 
     let contexts = &*contexts_ptr;
-    if let Option::Some(mut current) = contexts.get(context_i) {
+    if let Option::Some(current) = contexts.get(context_i) {
         for i in 0..current.files.len() {
             if let Option::Some(file) = current.files.get(i) {
                 if file.fd == fd {

--- a/src/usb/src/ehci.rs
+++ b/src/usb/src/ehci.rs
@@ -1,9 +1,6 @@
-use core::intrinsics::{volatile_load, volatile_store};
 use core::ptr::{read, write};
 
 use common::debug;
-use common::scheduler;
-use common::time::{self, Duration};
 
 use drivers::pciconfig::*;
 


### PR DESCRIPTION
This fixes warnings all over the code.

I left the warnings that only happen because of missing or temporary commented out sections.