### PR TITLE
Opening Programs from the UI Bar Change

### DIFF
--- a/src/programs/src/session.rs
+++ b/src/programs/src/session.rs
@@ -180,7 +180,7 @@ impl Session {
         let mut catcher = -1;
 
         if mouse_event.y >= self.display.height as isize - 32 {
-            if mouse_event.left_button && !self.last_mouse_event.left_button {
+            if !mouse_event.left_button && self.last_mouse_event.left_button {
                 let mut x = 0;
                 for package in self.packages.iter() {
                     if package.icon.data.len() > 0 {


### PR DESCRIPTION
Rather than open programs from the UI bar on mouse down, this change
opens programs only on a mouse up.

This allows for potentially adding a "Drag UI bar icons around to customize
which ones are there, or modify their position" type of feature, as well
as prevent unintentionally opening programs the user wants to avoid (which
will be most valuable for preventing heavy program startups) when they
click down, but don't click up.