### PR TITLE
Changed Fedora setup instructions to use dnf instead of yum

### DIFF
--- a/setup/fedora.sh
+++ b/setup/fedora.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-sudo yum install gcc gcc-c++ glibc-devel.i686 nasm make
+sudo dnf install gcc gcc-c++ glibc-devel.i686 nasm make


### PR DESCRIPTION
On Fedora it's preferred to use dnf now that yum has been deprecated.