### PR TITLE
Removed string field from `Lines`-iterator

### DIFF
--- a/kernel/common/string.rs
+++ b/kernel/common/string.rs
@@ -80,8 +80,6 @@ impl <'a> Iterator for Split<'a> {
 
 /// A set of lines
 pub struct Lines<'a> {
-    /// The string being split into lines
-    string: &'a String,
     /// The underlying split
     split: Split<'a>
 }
@@ -314,7 +312,6 @@ impl String {
     /// Get a iterator of lines from the string
     pub fn lines(&self) -> Lines {
         Lines {
-            string: &self,
             split: self.split("\n".to_string())
         }
     }


### PR DESCRIPTION
We don't need it for the iterator itself, neither is there a way to get
the original string back from iterator, so why save it there? Also it is
already saved in `Split`, where it is actually needed by the algorithm. So
keeping the string in `Lines` would just double the memory footprint for
nothing.

Sorry for not realising that when sending first PR.