### PR TITLE
Lots of ZFS cleanup

### DIFF
--- a/filesystem/apps/zfs/block_ptr.rs
+++ b/filesystem/apps/zfs/block_ptr.rs
@@ -1,0 +1,56 @@
+use super::from_bytes::FromBytes;
+use super::dvaddr::DVAddr;
+
+#[derive(Copy, Clone, Debug)]
+#[repr(packed)]
+pub struct BlockPtr {
+    pub dvas: [DVAddr; 3],
+    pub flags_size: u64,
+    pub padding: [u64; 3],
+    pub birth_txg: u64,
+    pub fill_count: u64,
+    pub checksum: [u64; 4],
+}
+
+impl BlockPtr {
+    pub fn level(&self) -> u64 {
+        (self.flags_size >> 56) & 0x7F
+    }
+
+    pub fn object_type(&self) -> u64 {
+        (self.flags_size >> 48) & 0xFF
+    }
+
+    pub fn checksum(&self) -> u64 {
+        (self.flags_size >> 40) & 0xFF
+    }
+
+    pub fn compression(&self) -> u64 {
+        (self.flags_size >> 32) & 0xFF
+    }
+
+    pub fn lsize(&self) -> u64 {
+        (self.flags_size & 0xFFFF) + 1
+    }
+
+    pub fn psize(&self) -> u64 {
+        ((self.flags_size >> 16) & 0xFFFF) + 1
+    }
+}
+
+impl FromBytes for BlockPtr { }
+
+#[derive(Copy, Clone, Debug)]
+#[repr(packed)]
+pub struct Gang {
+    pub bps: [BlockPtr; 3],
+    pub padding: [u64; 14],
+    pub magic: u64,
+    pub checksum: u64,
+}
+
+impl Gang {
+    pub fn magic() -> u64 {
+        return 0x117a0cb17ada1002;
+    }
+}

--- a/filesystem/apps/zfs/dnode.rs
+++ b/filesystem/apps/zfs/dnode.rs
@@ -3,7 +3,7 @@ use redox::mem;
 
 use super::block_ptr::BlockPtr;
 use super::from_bytes::FromBytes;
-use super::ZilHeader;
+use super::zil_header::ZilHeader;
 
 #[repr(packed)]
 pub struct DNodePhys {

--- a/filesystem/apps/zfs/dnode.rs
+++ b/filesystem/apps/zfs/dnode.rs
@@ -1,0 +1,59 @@
+use redox::fmt;
+use redox::mem;
+
+use super::block_ptr::BlockPtr;
+use super::from_bytes::FromBytes;
+use super::ZilHeader;
+
+#[repr(packed)]
+pub struct DNodePhys {
+    pub object_type: u8,
+    pub indblkshift: u8, // ln2(indirect block size)
+    pub nlevels: u8, // 1=blkptr->data blocks
+    pub nblkptr: u8, // length of blkptr
+    pub bonus_type: u8, // type of data in bonus buffer
+    pub checksum: u8, // ZIO_CHECKSUM type
+    pub compress: u8, // ZIO_COMPRESS type
+    pub flags: u8, // DNODE_FLAG_*
+    pub data_blk_sz_sec: u16, // data block size in 512b sectors
+    pub bonus_len: u16, // length of bonus
+    pub pad2: [u8; 4],
+
+    // accounting is protected by dirty_mtx
+    pub maxblkid: u64, // largest allocated block ID
+    pub used: u64, // bytes (or sectors) of disk space
+
+    pub pad3: [u64; 4],
+
+    blkptr_bonus: [u8; 448],
+}
+
+impl DNodePhys {
+    pub fn get_blockptr<'a>(&self, i: usize) -> &'a BlockPtr {
+        unsafe { mem::transmute(&self.blkptr_bonus[i*128]) }
+    }
+
+    pub fn get_bonus(&self) -> &[u8] {
+        &self.blkptr_bonus[(self.nblkptr as usize)*128..]
+    }
+}
+
+impl FromBytes for DNodePhys { }
+
+impl fmt::Debug for DNodePhys {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        try!(write!(f, "DNodePhys {{ object_type: {:X}, nlevels: {:X}, nblkptr: {:X}, bonus_type: {:X}, bonus_len: {:X}}}\n",
+                    self.object_type, self.nlevels, self.nblkptr, self.bonus_type, self.bonus_len));
+        Ok(())
+    }
+}
+
+#[repr(packed)]
+pub struct ObjectSetPhys {
+    pub meta_dnode: DNodePhys,
+    pub zil_header: ZilHeader,
+    pub os_type: u64,
+    //pad: [u8; 360],
+}
+
+impl FromBytes for ObjectSetPhys { }

--- a/filesystem/apps/zfs/dsl_dataset.rs
+++ b/filesystem/apps/zfs/dsl_dataset.rs
@@ -1,4 +1,4 @@
-use super::BlockPtr;
+use super::block_ptr::BlockPtr;
 use super::from_bytes::FromBytes;
 
 #[repr(packed)]

--- a/filesystem/apps/zfs/dvaddr.rs
+++ b/filesystem/apps/zfs/dvaddr.rs
@@ -1,0 +1,41 @@
+use redox::fmt;
+
+use super::from_bytes::FromBytes;
+
+#[derive(Copy, Clone)]
+#[repr(packed)]
+pub struct DVAddr {
+    pub vdev: u64,
+    pub offset: u64,
+}
+
+impl DVAddr {
+    /// Sector address is the offset plus two vdev labels and one boot block (4 MB, or 8192 sectors)
+    pub fn sector(&self) -> u64 {
+        self.offset() + 0x2000
+    }
+
+    pub fn gang(&self) -> bool {
+        if self.offset&0x8000000000000000 == 1 {
+            true
+        } else {
+            false
+        }
+    }
+
+    pub fn offset(&self) -> u64 {
+        self.offset & 0x7FFFFFFFFFFFFFFF
+    }
+
+    pub fn asize(&self) -> u64 {
+        (self.vdev & 0xFFFFFF) + 1
+    }
+}
+
+impl fmt::Debug for DVAddr {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        try!(write!(f, "DVAddr {{ offset: {:X}, gang: {}, asize: {:X} }}\n",
+                    self.offset(), self.gang(), self.asize()));
+        Ok(())
+    }
+}

--- a/filesystem/apps/zfs/uberblock.rs
+++ b/filesystem/apps/zfs/uberblock.rs
@@ -2,7 +2,7 @@ use redox::mem;
 use redox::ptr;
 
 use super::from_bytes::FromBytes;
-use super::BlockPtr;
+use super::block_ptr::BlockPtr;
 
 #[derive(Copy, Clone, Debug)]
 #[repr(packed)]

--- a/filesystem/apps/zfs/uberblock.rs
+++ b/filesystem/apps/zfs/uberblock.rs
@@ -1,0 +1,42 @@
+use redox::mem;
+use redox::ptr;
+
+use super::from_bytes::FromBytes;
+use super::BlockPtr;
+
+#[derive(Copy, Clone, Debug)]
+#[repr(packed)]
+pub struct Uberblock {
+    pub magic: u64,
+    pub version: u64,
+    pub txg: u64,
+    pub guid_sum: u64,
+    pub timestamp: u64,
+    pub rootbp: BlockPtr,
+}
+
+impl Uberblock {
+    pub fn magic_little() -> u64 {
+        return 0x0cb1ba00;
+    }
+
+    pub fn magic_big() -> u64 {
+        return 0x00bab10c;
+    }
+
+}
+
+impl FromBytes for Uberblock {
+    fn from_bytes(data: &[u8]) -> Option<Self> {
+        if data.len() >= mem::size_of::<Uberblock>() {
+            let uberblock = unsafe { ptr::read(data.as_ptr() as *const Uberblock) };
+            if uberblock.magic == Uberblock::magic_little() {
+                return Some(uberblock);
+            } else if uberblock.magic == Uberblock::magic_big() {
+                return Some(uberblock);
+            }
+        }
+
+        None
+    }
+}

--- a/filesystem/apps/zfs/vdev.rs
+++ b/filesystem/apps/zfs/vdev.rs
@@ -1,0 +1,12 @@
+use super::from_bytes::FromBytes;
+use super::Uberblock;
+
+#[repr(packed)]
+pub struct VdevLabel {
+    pub blank: [u8; 8 * 1024],
+    pub boot_header: [u8; 8 * 1024],
+    pub nv_pairs: [u8; 112 * 1024],
+    pub uberblocks: [Uberblock; 128],
+}
+
+impl FromBytes for VdevLabel { }

--- a/filesystem/apps/zfs/vdev.rs
+++ b/filesystem/apps/zfs/vdev.rs
@@ -1,5 +1,5 @@
 use super::from_bytes::FromBytes;
-use super::Uberblock;
+use super::uberblock::Uberblock;
 
 #[repr(packed)]
 pub struct VdevLabel {

--- a/filesystem/apps/zfs/zfs.rs
+++ b/filesystem/apps/zfs/zfs.rs
@@ -1,6 +1,7 @@
 //To use this, please install zfs-fuse
 use redox::*;
 
+use self::block_ptr::BlockPtr;
 use self::dsl_dataset::DslDatasetPhys;
 use self::dsl_dir::DslDirPhys;
 use self::dvaddr::DVAddr;
@@ -8,6 +9,7 @@ use self::from_bytes::FromBytes;
 use self::uberblock::Uberblock;
 use self::vdev::VdevLabel;
 
+pub mod block_ptr;
 pub mod dsl_dataset;
 pub mod dsl_dir;
 pub mod dvaddr;
@@ -19,60 +21,6 @@ pub mod uberblock;
 pub mod vdev;
 pub mod xdr;
 pub mod zap;
-
-#[derive(Copy, Clone, Debug)]
-#[repr(packed)]
-pub struct BlockPtr {
-    pub dvas: [DVAddr; 3],
-    pub flags_size: u64,
-    pub padding: [u64; 3],
-    pub birth_txg: u64,
-    pub fill_count: u64,
-    pub checksum: [u64; 4],
-}
-
-impl BlockPtr {
-    pub fn level(&self) -> u64 {
-        (self.flags_size >> 56) & 0x7F
-    }
-
-    pub fn object_type(&self) -> u64 {
-        (self.flags_size >> 48) & 0xFF
-    }
-
-    pub fn checksum(&self) -> u64 {
-        (self.flags_size >> 40) & 0xFF
-    }
-
-    pub fn compression(&self) -> u64 {
-        (self.flags_size >> 32) & 0xFF
-    }
-
-    pub fn lsize(&self) -> u64 {
-        (self.flags_size & 0xFFFF) + 1
-    }
-
-    pub fn psize(&self) -> u64 {
-        ((self.flags_size >> 16) & 0xFFFF) + 1
-    }
-}
-
-impl FromBytes for BlockPtr { }
-
-#[derive(Copy, Clone, Debug)]
-#[repr(packed)]
-pub struct Gang {
-    pub bps: [BlockPtr; 3],
-    pub padding: [u64; 14],
-    pub magic: u64,
-    pub checksum: u64,
-}
-
-impl Gang {
-    pub fn magic() -> u64 {
-        return 0x117a0cb17ada1002;
-    }
-}
 
 #[repr(packed)]
 pub struct DNodePhys {

--- a/filesystem/apps/zfs/zfs.rs
+++ b/filesystem/apps/zfs/zfs.rs
@@ -4,6 +4,7 @@ use redox::*;
 use self::dsl_dataset::DslDatasetPhys;
 use self::dsl_dir::DslDirPhys;
 use self::from_bytes::FromBytes;
+use self::vdev::VdevLabel;
 
 pub mod dsl_dataset;
 pub mod dsl_dir;
@@ -11,18 +12,9 @@ pub mod from_bytes;
 pub mod lzjb;
 pub mod nvpair;
 pub mod nvstream;
+pub mod vdev;
 pub mod xdr;
 pub mod zap;
-
-#[repr(packed)]
-pub struct VdevLabel {
-    pub blank: [u8; 8 * 1024],
-    pub boot_header: [u8; 8 * 1024],
-    pub nv_pairs: [u8; 112 * 1024],
-    pub uberblocks: [Uberblock; 128],
-}
-
-impl FromBytes for VdevLabel { }
 
 #[derive(Copy, Clone, Debug)]
 #[repr(packed)]

--- a/filesystem/apps/zfs/zfs.rs
+++ b/filesystem/apps/zfs/zfs.rs
@@ -3,12 +3,14 @@ use redox::*;
 
 use self::dsl_dataset::DslDatasetPhys;
 use self::dsl_dir::DslDirPhys;
+use self::dvaddr::DVAddr;
 use self::from_bytes::FromBytes;
 use self::uberblock::Uberblock;
 use self::vdev::VdevLabel;
 
 pub mod dsl_dataset;
 pub mod dsl_dir;
+pub mod dvaddr;
 pub mod from_bytes;
 pub mod lzjb;
 pub mod nvpair;
@@ -17,44 +19,6 @@ pub mod uberblock;
 pub mod vdev;
 pub mod xdr;
 pub mod zap;
-
-#[derive(Copy, Clone)]
-#[repr(packed)]
-pub struct DVAddr {
-    pub vdev: u64,
-    pub offset: u64,
-}
-
-impl DVAddr {
-    /// Sector address is the offset plus two vdev labels and one boot block (4 MB, or 8192 sectors)
-    pub fn sector(&self) -> u64 {
-        self.offset() + 0x2000
-    }
-
-    pub fn gang(&self) -> bool {
-        if self.offset&0x8000000000000000 == 1 {
-            true
-        } else {
-            false
-        }
-    }
-
-    pub fn offset(&self) -> u64 {
-        self.offset & 0x7FFFFFFFFFFFFFFF
-    }
-
-    pub fn asize(&self) -> u64 {
-        (self.vdev & 0xFFFFFF) + 1
-    }
-}
-
-impl fmt::Debug for DVAddr {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        try!(write!(f, "DVAddr {{ offset: {:X}, gang: {}, asize: {:X} }}\n",
-                    self.offset(), self.gang(), self.asize()));
-        Ok(())
-    }
-}
 
 #[derive(Copy, Clone, Debug)]
 #[repr(packed)]

--- a/filesystem/apps/zfs/zfs.rs
+++ b/filesystem/apps/zfs/zfs.rs
@@ -4,6 +4,7 @@ use redox::*;
 use self::dsl_dataset::DslDatasetPhys;
 use self::dsl_dir::DslDirPhys;
 use self::from_bytes::FromBytes;
+use self::uberblock::Uberblock;
 use self::vdev::VdevLabel;
 
 pub mod dsl_dataset;
@@ -12,48 +13,10 @@ pub mod from_bytes;
 pub mod lzjb;
 pub mod nvpair;
 pub mod nvstream;
+pub mod uberblock;
 pub mod vdev;
 pub mod xdr;
 pub mod zap;
-
-#[derive(Copy, Clone, Debug)]
-#[repr(packed)]
-pub struct Uberblock {
-    pub magic: u64,
-    pub version: u64,
-    pub txg: u64,
-    pub guid_sum: u64,
-    pub timestamp: u64,
-    pub rootbp: BlockPtr,
-}
-
-impl Uberblock {
-    pub fn magic_little() -> u64 {
-        return 0x0cb1ba00;
-    }
-
-    pub fn magic_big() -> u64 {
-        return 0x00bab10c;
-    }
-
-}
-
-impl FromBytes for Uberblock {
-    fn from_bytes(data: &[u8]) -> Option<Self> {
-        if data.len() >= mem::size_of::<Uberblock>() {
-            let uberblock = unsafe { ptr::read(data.as_ptr() as *const Uberblock) };
-            if uberblock.magic == Uberblock::magic_little() {
-                return Some(uberblock);
-            } else if uberblock.magic == Uberblock::magic_big() {
-                return Some(uberblock);
-            } else if uberblock.magic > 0 {
-                println!("Unknown Magic: {:X}", uberblock.magic as usize);
-            }
-        }
-
-        None
-    }
-}
 
 #[derive(Copy, Clone)]
 #[repr(packed)]

--- a/filesystem/apps/zfs/zil_header.rs
+++ b/filesystem/apps/zfs/zil_header.rs
@@ -1,0 +1,8 @@
+use super::block_ptr::BlockPtr;
+
+#[repr(packed)]
+pub struct ZilHeader {
+    claim_txg: u64,
+    replay_seq: u64,
+    log: BlockPtr,
+}


### PR DESCRIPTION
- separated structs in zfs.rs to their own files
- created `ZFS::traverse` and use it to implement `read_file` and `ls` to reduce duplicated code
- added comments