### PR TITLE
Have to explicitly match or will still `1 + string.len()`

### DIFF
--- a/kernel/schemes/mod.rs
+++ b/kernel/schemes/mod.rs
@@ -146,7 +146,12 @@ impl URL {
 
     /// Get the reference (after the ':') of the url
     pub fn reference(&self) -> &str {
-        &self.string[(1 + self.string.find(':').unwrap_or(self.string.len()))..]
+        &self.string[
+        match self.string.find(':') {
+            Some(pos) => pos + 1,
+            None => self.string.len(),
+        }
+        ..]
     }
 
 }


### PR DESCRIPTION
Apparently `unwrap_or` is not great for everything.