### PR TITLE
x86_64 now compiles; fails when loading idt.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -177,8 +177,12 @@ $(BUILD)/kernel.bin: $(BUILD)/kernel.rlib kernel/kernel.ld
 $(BUILD)/kernel.list: $(BUILD)/kernel.bin
 	$(OBJDUMP) -C -M intel -D $< > $@
 
-$(BUILD)/crt0.o: kernel/program.asm
-	$(AS) -f elf $< -o $@
+$(BUILD)/crt0.o: kernel/program-$(ARCH).asm
+	if [ "$(ARCH)" == "x86_64" ]; then \
+		$(AS) -f elf64 $< -o $@; \
+	else \
+		$(AS) -f elf $< -o $@; \
+	fi
 
 filesystem/apps/%.bin: filesystem/apps/%.rs kernel/program.rs kernel/program.ld $(BUILD)/crt0.o $(BUILD)/libcore.rlib $(BUILD)/liballoc.rlib $(BUILD)/libredox.rlib
 	$(SED) "s|APPLICATION_PATH|../../$<|" kernel/program.rs > $(BUILD)/`$(BASENAME) $*`.gen

--- a/kernel/common/context.rs
+++ b/kernel/common/context.rs
@@ -249,6 +249,7 @@ impl Context {
             fx_enabled: false,
             memory: Vec::new(),
             cwd: String::new(),
+            args: Vec::new(),
             files: Vec::new(),
             interrupted: false,
             exited: false,

--- a/kernel/loader-x86_64.asm
+++ b/kernel/loader-x86_64.asm
@@ -47,6 +47,7 @@ load:
     sub cx, 64
 
     jmp load
+
 .good_size:
     mov [DAPACK.addr], ax
     mov [DAPACK.buf], bx

--- a/kernel/program-i386.asm
+++ b/kernel/program-i386.asm
@@ -1,0 +1,10 @@
+extern _start_stack
+section .text
+global _start
+_start:
+	push esp
+	call _start_stack
+	add esp, 4
+	mov eax, 1
+	xor ebx, ebx
+	int 0x80

--- a/kernel/program-x86_64.asm
+++ b/kernel/program-x86_64.asm
@@ -1,0 +1,10 @@
+extern _start_stack
+section .text
+global _start
+_start:
+	push rsp
+	call _start_stack
+	add rsp, 4
+	mov rax, 1
+	xor rbx, rbx
+	int 0x80


### PR DESCRIPTION
This is definitely not complete.

Right now it compiles when `ARCH=x86_64` and gets to the boot screen, it fails to load the interrupt descriptor table though.

refs #53 