### PR TITLE
Add debug! and debugln! macros for debug syscalls (to print to system console)

### DIFF
--- a/libredox/src/console.rs
+++ b/libredox/src/console.rs
@@ -73,6 +73,24 @@ macro_rules! println {
     });
 }
 
+
+/// Debug new line to console
+#[macro_export]
+macro_rules! debugln {
+    ($($arg:tt)*) => ({
+        debug!($($arg)*);
+        debug!("\n");
+    });
+}
+
+/// Debug to console
+#[macro_export]
+macro_rules! debug {
+    ($($arg:tt)*) => ({
+        $crate::debug::debug(format!($($arg)*));
+    });
+}
+
 /// Print new line to console with color
 #[macro_export]
 macro_rules! println_color {

--- a/libredox/src/debug.rs
+++ b/libredox/src/debug.rs
@@ -1,0 +1,9 @@
+use super::syscall::sys_debug;
+
+pub fn debug<T: AsRef<str>>(msg: T) {
+    for b in msg.as_ref().bytes() {
+        unsafe {
+            sys_debug(b);
+        }
+    }
+}

--- a/libredox/src/lib.rs
+++ b/libredox/src/lib.rs
@@ -73,6 +73,7 @@
     pub use core::result;
     pub use core::option;
     pub mod error;
+    pub mod debug;
 
     pub use alloc::boxed;
     pub use alloc::rc;

--- a/libredox/src/macros.rs
+++ b/libredox/src/macros.rs
@@ -96,6 +96,7 @@ macro_rules! print {
     ($($arg:tt)*) => ($crate::io::_print(format_args!($($arg)*)));
 }
 
+
 /// Macro for printing to the standard output, with a newline.
 ///
 /// Use the `format!` syntax to write data to the standard output.


### PR DESCRIPTION
I thought this was needed for debugging.