### PR TITLE
Implement get_slice() for bounded slice abstraction

### DIFF
--- a/kernel/kernel.rs
+++ b/kernel/kernel.rs
@@ -143,10 +143,10 @@ static mut events_ptr: *mut Queue<Event> = 0 as *mut Queue<Event>;
 /// foo[a..]  => foo.get_slice(Some(a), None)
 /// foo[..b]  => foo.get_slice(None, Some(b))
 /// ```
-pub trait GetSlice { fn get_slice(&self, a: Option<usize>, b: Option<usize>) -> Self; }
+pub trait GetSlice { fn get_slice(&self, a: Option<usize>, b: Option<usize>) -> &Self; }
 
-impl<'a> GetSlice for &'a str {
-    fn get_slice(&self, a: Option<usize>, b: Option<usize>) -> Self {
+impl GetSlice for str {
+    fn get_slice(&self, a: Option<usize>, b: Option<usize>) -> &Self {
         let slice = unsafe { slice::from_raw_parts(self.repr().data, self.repr().len) };
         let a = a.unwrap_or(0);
         let b = if let Some(tmp) = b {
@@ -160,9 +160,9 @@ impl<'a> GetSlice for &'a str {
     }
 }
 
-impl<'a, T> GetSlice for &'a [T] {
-    fn get_slice(&self, a: Option<usize>, b: Option<usize>) -> Self {
-        let slice = unsafe { slice::from_raw_parts(SliceExt::as_ptr(*self), SliceExt::len(*self)) };
+impl<T> GetSlice for [T] {
+    fn get_slice(&self, a: Option<usize>, b: Option<usize>) -> &Self {
+        let slice = unsafe { slice::from_raw_parts(SliceExt::as_ptr(self), SliceExt::len(self)) };
         let a = a.unwrap_or(0);
         let b = if let Some(tmp) = b {
             let len = slice.len();

--- a/kernel/kernel.rs
+++ b/kernel/kernel.rs
@@ -137,11 +137,11 @@ static mut session_ptr: *mut Session = 0 as *mut Session;
 /// Event pointer
 static mut events_ptr: *mut Queue<Event> = 0 as *mut Queue<Event>;
 
-/// Safer slice abstraction
+/// Bounded slice abstraction
 /// ```
-/// foo[a..b] => foo.get_slice(a, b)
-/// foo[a..]  => foo.get_slice(a, None)
-/// foo[..b]  => foo.get_slice(None, b)
+/// foo[a..b] => foo.get_slice(Some(a), Some(b))
+/// foo[a..]  => foo.get_slice(Some(a), None)
+/// foo[..b]  => foo.get_slice(None, Some(b))
 /// ```
 pub trait GetSlice { fn get_slice(&self, a: Option<usize>, b: Option<usize>) -> Self; }
 

--- a/kernel/kernel.rs
+++ b/kernel/kernel.rs
@@ -151,7 +151,7 @@ impl GetSlice for str {
         let a = if let Some(tmp) = a {
             let len = slice.len();
             if tmp > len { len }
-            else { 0 }
+            else { tmp }
         } else {
             0
         };
@@ -172,7 +172,7 @@ impl<T> GetSlice for [T] {
         let a = if let Some(tmp) = a {
             let len = slice.len();
             if tmp > len { len }
-            else { 0 }
+            else { tmp }
         } else {
             0
         };

--- a/kernel/kernel.rs
+++ b/kernel/kernel.rs
@@ -7,6 +7,7 @@
 #![feature(core_intrinsics)]
 #![feature(core_simd)]
 #![feature(core_str_ext)]
+#![feature(core_slice_ext)]
 #![feature(fnbox)]
 #![feature(fundamental)]
 #![feature(lang_items)]
@@ -15,6 +16,7 @@
 #![feature(unsafe_no_drop_flag)]
 #![feature(unwind_attributes)]
 #![feature(vec_push_all)]
+#![feature(raw)]
 #![feature(slice_concat_ext)]
 #![no_std]
 
@@ -30,6 +32,9 @@ use collections::string::{String, ToString};
 use collections::vec::Vec;
 
 use core::{mem, ptr};
+use core::slice::{self, SliceExt};
+use core::str;
+use core::raw::Repr;
 
 use common::context::*;
 use common::debug;
@@ -131,6 +136,32 @@ static mut session_ptr: *mut Session = 0 as *mut Session;
 
 /// Event pointer
 static mut events_ptr: *mut Queue<Event> = 0 as *mut Queue<Event>;
+
+/// Safer slice abstraction
+/// ```
+/// foo[a..b] => foo.get_slice(a, b)
+/// foo[a..]  => foo.get_slice(a, None)
+/// foo[..b]  => foo.get_slice(None, b)
+/// ```
+pub trait GetSlice { fn get_slice(&self, a: Option<usize>, b: Option<usize>) -> Self; }
+
+impl<'a> GetSlice for &'a str {
+    fn get_slice(&self, a: Option<usize>, b: Option<usize>) -> Self {
+        let slice = unsafe { slice::from_raw_parts(self.repr().data, self.repr().len) };
+        let a = a.unwrap_or(0);
+        let b = b.unwrap_or(slice.len());
+        unsafe { str::from_utf8_unchecked(&slice[a..b]) }
+    }
+}
+
+impl<'a, T> GetSlice for &'a [T] {
+    fn get_slice(&self, a: Option<usize>, b: Option<usize>) -> Self {
+        let slice = unsafe { slice::from_raw_parts(SliceExt::as_ptr(*self), SliceExt::len(*self)) };
+        let a = a.unwrap_or(0);
+        let b = b.unwrap_or(slice.len());
+        &slice[a..b]
+    }
+}
 
 /// Idle loop (active while idle)
 unsafe fn idle_loop() -> ! {

--- a/kernel/kernel.rs
+++ b/kernel/kernel.rs
@@ -148,7 +148,13 @@ pub trait GetSlice { fn get_slice(&self, a: Option<usize>, b: Option<usize>) -> 
 impl GetSlice for str {
     fn get_slice(&self, a: Option<usize>, b: Option<usize>) -> &Self {
         let slice = unsafe { slice::from_raw_parts(self.repr().data, self.repr().len) };
-        let a = a.unwrap_or(0);
+        let a = if let Some(tmp) = a {
+            let len = slice.len();
+            if tmp > len { len }
+            else { 0 }
+        } else {
+            0
+        };
         let b = if let Some(tmp) = b {
             let len = slice.len();
             if tmp > len { len }
@@ -163,7 +169,13 @@ impl GetSlice for str {
 impl<T> GetSlice for [T] {
     fn get_slice(&self, a: Option<usize>, b: Option<usize>) -> &Self {
         let slice = unsafe { slice::from_raw_parts(SliceExt::as_ptr(self), SliceExt::len(self)) };
-        let a = a.unwrap_or(0);
+        let a = if let Some(tmp) = a {
+            let len = slice.len();
+            if tmp > len { len }
+            else { 0 }
+        } else {
+            0
+        };
         let b = if let Some(tmp) = b {
             let len = slice.len();
             if tmp > len { len }

--- a/kernel/kernel.rs
+++ b/kernel/kernel.rs
@@ -149,7 +149,13 @@ impl<'a> GetSlice for &'a str {
     fn get_slice(&self, a: Option<usize>, b: Option<usize>) -> Self {
         let slice = unsafe { slice::from_raw_parts(self.repr().data, self.repr().len) };
         let a = a.unwrap_or(0);
-        let b = b.unwrap_or(slice.len());
+        let b = if let Some(tmp) = b {
+            let len = slice.len();
+            if tmp > len { len }
+            else { tmp }
+        } else {
+            slice.len()
+        };
         unsafe { str::from_utf8_unchecked(&slice[a..b]) }
     }
 }
@@ -158,7 +164,13 @@ impl<'a, T> GetSlice for &'a [T] {
     fn get_slice(&self, a: Option<usize>, b: Option<usize>) -> Self {
         let slice = unsafe { slice::from_raw_parts(SliceExt::as_ptr(*self), SliceExt::len(*self)) };
         let a = a.unwrap_or(0);
-        let b = b.unwrap_or(slice.len());
+        let b = if let Some(tmp) = b {
+            let len = slice.len();
+            if tmp > len { len }
+            else { tmp }
+        } else {
+            slice.len()
+        };
         &slice[a..b]
     }
 }


### PR DESCRIPTION
Implemented the long awaited get_slice() method for both `&str` and `&[T]` :tada: