### PR TITLE
Adjust the type name acronym casing to fit the Rust convention

### DIFF
--- a/filesystem/apps/file_manager/file_manager.rs
+++ b/filesystem/apps/file_manager/file_manager.rs
@@ -1,4 +1,4 @@
-use redox::{self, cmp, env, BMPFile, Color};
+use redox::{self, cmp, env, BmpFile, Color};
 use redox::collections::BTreeMap;
 use redox::event::{self, EventOption, MouseEvent};
 use redox::fs::{self, File};
@@ -10,7 +10,7 @@ use redox::string::{String, ToString};
 
 pub struct FileType {
     description: String,
-    icon: BMPFile,
+    icon: BmpFile,
 }
 
 impl FileType {
@@ -29,12 +29,12 @@ pub struct FileManager {
     click_time: Duration,
 }
 
-fn load_icon(path: &str) -> BMPFile {
+fn load_icon(path: &str) -> BmpFile {
     let mut vec: Vec<u8> = Vec::new();
     if let Some(mut file) = File::open(&("file:///ui/mimetypes/".to_string() + path + ".bmp")) {
         file.read_to_end(&mut vec);
     }
-    BMPFile::from_data(&vec)
+    BmpFile::from_data(&vec)
 }
 
 impl FileManager {

--- a/filesystem/apps/player/player.rs
+++ b/filesystem/apps/player/player.rs
@@ -18,7 +18,7 @@ pub fn main() {
                                  &("Player (".to_string() + &url + ")")).unwrap();
     window.sync();
 
-    let wav = WAV::from_data(&vec);
+    let wav = WavFile::from_data(&vec);
 
     if let Some(mut audio) = File::open("audio://") {
         audio.write(&wav.data);

--- a/filesystem/apps/viewer/viewer.rs
+++ b/filesystem/apps/viewer/viewer.rs
@@ -13,7 +13,7 @@ pub fn main() {
         file.read_to_end(&mut vec);
     }
 
-    let bmp = BMPFile::from_data(&vec);
+    let bmp = BmpFile::from_data(&vec);
     let mut window = Window::new((rand() % 400 + 50) as isize,
                                  (rand() % 300 + 50) as isize,
                                  max(320, bmp.width()),

--- a/filesystem/apps/zfs/zfs.rs
+++ b/filesystem/apps/zfs/zfs.rs
@@ -116,7 +116,7 @@ pub enum ZfsTraverse {
     Done,
 }
 
-pub struct ZFS {
+pub struct Zfs {
     pub reader: ZfsReader,
     pub uberblock: Uberblock, // The active uberblock
     pub mos: ObjectSetPhys,
@@ -125,7 +125,7 @@ pub struct ZFS {
     root: u64,
 }
 
-impl ZFS {
+impl Zfs {
     pub fn new(disk: File) -> Result<Self, String> {
         let mut zfs_reader = ZfsReader { disk: disk };
 
@@ -176,7 +176,7 @@ impl ZFS {
                 None => Err("Error: failed to get the ROOT".to_string()),
             };
 
-        Ok(ZFS {
+        Ok(Zfs {
             reader: zfs_reader,
             uberblock: uberblock,
             mos: mos,
@@ -187,7 +187,7 @@ impl ZFS {
     }
 
     pub fn traverse<F, T>(&mut self, mut f: F) -> Option<T>
-        where F: FnMut(&mut ZFS, &str, usize, &mut DNodePhys, &BlockPtr, &mut Option<T>) -> Option<ZfsTraverse>,
+        where F: FnMut(&mut Self, &str, usize, &mut DNodePhys, &BlockPtr, &mut Option<T>) -> Option<ZfsTraverse>,
     {
         // Given the fs_objset and the object id of the root directory, we can traverse the
         // directory tree.
@@ -347,7 +347,7 @@ pub fn main() {
 
     println!("Type open zfs.img to open the image file");
 
-    let mut zfs_option: Option<ZFS> = None;
+    let mut zfs_option: Option<Zfs> = None;
 
     while let Some(line) = readln!() {
         let mut args: Vec<String> = Vec::new();
@@ -527,7 +527,7 @@ pub fn main() {
                                 match File::open(arg) {
                                     Some(file) => {
                                         println_color!(green, "Open: {}", arg);
-                                        zfs_option = ZFS::new(file).ok();
+                                        zfs_option = Zfs::new(file).ok();
                                     },
                                     None => println_color!(red, "File not found!"),
                                 }

--- a/filesystem/schemes/zfs/zfs.rs
+++ b/filesystem/schemes/zfs/zfs.rs
@@ -413,7 +413,7 @@ impl Scheme {
         }
 
         if let Some(ref mut zfs) = self.zfs {
-            let url = URL::from_str(&url_str);
+            let url = Url::from_str(&url_str);
 
             let path = url.path();
             if path.ends_with("/") {

--- a/kernel/audio/ac97.rs
+++ b/kernel/audio/ac97.rs
@@ -4,10 +4,10 @@ use core::{cmp, ptr, mem};
 
 use common::debug;
 use common::memory;
-use schemes::{Resource, ResourceSeek, URL};
+use schemes::{Resource, ResourceSeek, Url};
 use common::time::{self, Duration};
 
-use drivers::pciconfig::PCIConfig;
+use drivers::pciconfig::PciConfig;
 use drivers::pio::*;
 
 use schemes::KScheme;
@@ -31,8 +31,8 @@ impl Resource for AC97Resource {
         })
     }
 
-    fn url(&self) -> URL {
-        URL::from_str("audio://")
+    fn url(&self) -> Url {
+        Url::from_str("audio://")
     }
 
     fn read(&mut self, _: &mut [u8]) -> Option<usize> {
@@ -43,18 +43,18 @@ impl Resource for AC97Resource {
         unsafe {
             let audio = self.audio as u16;
 
-            let mut master_volume = PIO16::new(audio + 2);
-            let mut pcm_volume = PIO16::new(audio + 0x18);
+            let mut master_volume = Pio16::new(audio + 2);
+            let mut pcm_volume = Pio16::new(audio + 0x18);
 
             master_volume.write(0x808);
             pcm_volume.write(0x808);
 
             let bus_master = self.bus_master as u16;
 
-            let mut po_bdbar = PIO32::new(bus_master + 0x10);
-            let po_civ = PIO8::new(bus_master + 0x14);
-            let mut po_lvi = PIO8::new(bus_master + 0x15);
-            let mut po_cr = PIO8::new(bus_master + 0x1B);
+            let mut po_bdbar = Pio32::new(bus_master + 0x10);
+            let po_civ = Pio8::new(bus_master + 0x14);
+            let mut po_lvi = Pio8::new(bus_master + 0x15);
+            let mut po_cr = Pio8::new(bus_master + 0x1B);
 
             loop {
                 if po_cr.read() & 1 == 0 {
@@ -181,7 +181,7 @@ impl KScheme for AC97 {
         "audio"
     }
 
-    fn open(&mut self, _: &URL) -> Option<Box<Resource>> {
+    fn open(&mut self, _: &Url) -> Option<Box<Resource>> {
         Some(box AC97Resource {
             audio: self.audio,
             bus_master: self.bus_master,
@@ -199,7 +199,7 @@ impl KScheme for AC97 {
 }
 
 impl AC97 {
-    pub unsafe fn new(mut pci: PCIConfig) -> Box<AC97> {
+    pub unsafe fn new(mut pci: PciConfig) -> Box<AC97> {
         pci.flag(4, 4, true); // Bus mastering
 
         let module = box AC97 {

--- a/kernel/audio/intelhda.rs
+++ b/kernel/audio/intelhda.rs
@@ -2,11 +2,11 @@ use alloc::boxed::Box;
 
 use core::{ptr, mem};
 
-use drivers::pciconfig::PCIConfig;
+use drivers::pciconfig::PciConfig;
 
 use common::debug;
 use common::memory;
-use schemes::{Resource, ResourceSeek, URL};
+use schemes::{Resource, ResourceSeek, Url};
 use scheduler;
 use common::time::{self, Duration};
 
@@ -54,8 +54,8 @@ impl Resource for IntelHDAResource {
         })
     }
 
-    fn url(&self) -> URL {
-        URL::from_str("hda://")
+    fn url(&self) -> Url {
+        Url::from_str("hda://")
     }
 
     fn read(&mut self, _: &mut [u8]) -> Option<usize> {
@@ -207,7 +207,7 @@ impl Resource for IntelHDAResource {
 }
 
 pub struct IntelHDA {
-    pub pci: PCIConfig,
+    pub pci: PciConfig,
     pub base: usize,
     pub memory_mapped: bool,
     pub irq: u8,
@@ -218,7 +218,7 @@ impl KScheme for IntelHDA {
         "hda"
     }
 
-    fn open(&mut self, _: &URL) -> Option<Box<Resource>> {
+    fn open(&mut self, _: &Url) -> Option<Box<Resource>> {
         Some(box IntelHDAResource { base: self.base })
     }
 

--- a/kernel/common/elf.rs
+++ b/kernel/common/elf.rs
@@ -15,14 +15,14 @@ pub mod elf_arch;
 pub mod elf_arch;
 
 /// An ELF executable
-pub struct ELF {
+pub struct Elf {
     pub data: usize,
 }
 
-impl ELF {
+impl Elf {
     /// Create a new empty ELF executable
     pub fn new() -> Self {
-        ELF { data: 0 }
+        Elf { data: 0 }
     }
 
     /// Create a ELF executable from data
@@ -43,14 +43,14 @@ impl ELF {
             }
         }
 
-        ELF { data: data }
+        Elf { data: data }
     }
 
     /// Debug
     pub unsafe fn d(&self) {
         if self.data > 0 {
             debug::d("Debug ELF\n");
-            let header = &*(self.data as *const ELFHeader);
+            let header = &*(self.data as *const ElfHeader);
 
             debug::d("Magic: ");
             for i in 0..4 {
@@ -116,17 +116,17 @@ impl ELF {
             debug::dd(header.sh_str_index as usize);
             debug::dl();
 
-            let sh_str_section = &*((self.data + header.sh_off as usize + header.sh_str_index as usize * header.sh_ent_len as usize) as *const ELFSection);
+            let sh_str_section = &*((self.data + header.sh_off as usize + header.sh_str_index as usize * header.sh_ent_len as usize) as *const ElfSection);
 
-            let mut sym_section = &*((self.data + header.sh_off as usize) as *const ELFSection);
+            let mut sym_section = &*((self.data + header.sh_off as usize) as *const ElfSection);
 
-            let mut str_section = &*((self.data + header.sh_off as usize) as *const ELFSection);
+            let mut str_section = &*((self.data + header.sh_off as usize) as *const ElfSection);
 
             debug::d("Program Headers:");
             debug::dl();
 
             for i in 0..header.ph_len {
-                let segment = &*((self.data + header.ph_off as usize + i as usize * header.ph_ent_len as usize) as *const ELFSegment);
+                let segment = &*((self.data + header.ph_off as usize + i as usize * header.ph_ent_len as usize) as *const ElfSegment);
 
                 debug::d("    Section ");
                 debug::dd(i as usize);
@@ -171,7 +171,7 @@ impl ELF {
             debug::dl();
 
             for i in 0..header.sh_len {
-                let section = &*((self.data + header.sh_off as usize + i as usize * header.sh_ent_len as usize) as *const ELFSection);
+                let section = &*((self.data + header.sh_off as usize + i as usize * header.sh_ent_len as usize) as *const ElfSection);
 
                 let section_name_ptr = (self.data + sh_str_section.off as usize + section.name as usize) as *const u8;
                 let mut section_name_len = 0;
@@ -241,7 +241,7 @@ impl ELF {
                     debug::dd(len as usize);
                     debug::dl();
                     for i in 0..len {
-                        let symbol = &*((self.data + sym_section.off as usize + i as usize * sym_section.ent_len as usize) as *const ELFSymbol);
+                        let symbol = &*((self.data + sym_section.off as usize + i as usize * sym_section.ent_len as usize) as *const ElfSymbol);
 
                         let symbol_name_ptr = (self.data + str_section.off as usize + symbol.name as usize) as *const u8;
                         let mut symbol_name_len = 0;
@@ -287,12 +287,12 @@ impl ELF {
         }
     }
 
-    pub unsafe fn load_segment(&self) -> Option<ELFSegment> {
+    pub unsafe fn load_segment(&self) -> Option<ElfSegment> {
         if self.data > 0 {
-            let header = &*(self.data as *const ELFHeader);
+            let header = &*(self.data as *const ElfHeader);
 
             for i in 0..header.ph_len {
-                let segment = ptr::read((self.data + header.ph_off as usize + i as usize * header.ph_ent_len as usize) as *const ELFSegment);
+                let segment = ptr::read((self.data + header.ph_off as usize + i as usize * header.ph_ent_len as usize) as *const ElfSegment);
 
                 if segment._type == 1 {
                     return Some(segment);
@@ -308,7 +308,7 @@ impl ELF {
         if self.data > 0 {
             // TODO: Support 64-bit version
             // TODO: Get information from program headers
-            let header = &*(self.data as *const ELFHeader);
+            let header = &*(self.data as *const ElfHeader);
             return header.entry as usize;
         }
 
@@ -318,16 +318,16 @@ impl ELF {
     /// ELF symbol
     pub unsafe fn symbol(&self, name: &str) -> usize {
         if self.data > 0 {
-            let header = &*(self.data as *const ELFHeader);
+            let header = &*(self.data as *const ElfHeader);
 
-            let sh_str_section = &*((self.data + header.sh_off as usize + header.sh_str_index as usize * header.sh_ent_len as usize) as *const ELFSection);
+            let sh_str_section = &*((self.data + header.sh_off as usize + header.sh_str_index as usize * header.sh_ent_len as usize) as *const ElfSection);
 
-            let mut sym_section = &*((self.data + header.sh_off as usize) as *const ELFSection);
+            let mut sym_section = &*((self.data + header.sh_off as usize) as *const ElfSection);
 
-            let mut str_section = &*((self.data + header.sh_off as usize) as *const ELFSection);
+            let mut str_section = &*((self.data + header.sh_off as usize) as *const ElfSection);
 
             for i in 0..header.sh_len {
-                let section = &*((self.data + header.sh_off as usize + i as usize * header.sh_ent_len as usize) as *const ELFSection);
+                let section = &*((self.data + header.sh_off as usize + i as usize * header.sh_ent_len as usize) as *const ElfSection);
 
                 let section_name_ptr = (self.data + sh_str_section.off as usize + section.name as usize) as *const u8;
                 let mut section_name_len = 0;
@@ -350,7 +350,7 @@ impl ELF {
                 if sym_section.ent_len > 0 {
                     let len = sym_section.len / sym_section.ent_len;
                     for i in 0..len {
-                        let symbol = &*((self.data + sym_section.off as usize + i as usize * sym_section.ent_len as usize) as *const ELFSymbol);
+                        let symbol = &*((self.data + sym_section.off as usize + i as usize * sym_section.ent_len as usize) as *const ElfSymbol);
 
                         let symbol_name_ptr = (self.data + str_section.off as usize + symbol.name as usize) as *const u8;
                         let mut symbol_name_len = 0;
@@ -380,7 +380,7 @@ impl ELF {
     }
 }
 
-impl Drop for ELF {
+impl Drop for Elf {
     fn drop(&mut self) {
         unsafe {
             if self.data > 0 {

--- a/kernel/common/elf_arch-i386.rs
+++ b/kernel/common/elf_arch-i386.rs
@@ -6,7 +6,7 @@ pub type ElfWord = u32;
 
 /// An ELF header
 #[repr(packed)]
-pub struct ELFHeader {
+pub struct ElfHeader {
     /// The "magic number" (4 bytes)
     pub magic: [u8; 4],
     /// 64 or 32 bit?
@@ -49,7 +49,7 @@ pub struct ELFHeader {
 
 /// An ELF segment
 #[repr(packed)]
-pub struct ELFSegment {
+pub struct ElfSegment {
     pub _type: ElfWord,
     pub off: ElfOff,
     pub vaddr: ElfAddr,
@@ -62,7 +62,7 @@ pub struct ELFSegment {
 
 /// An ELF section
 #[repr(packed)]
-pub struct ELFSection {
+pub struct ElfSection {
     pub name: ElfWord,
     pub _type: ElfWord,
     pub flags: ElfWord,
@@ -77,7 +77,7 @@ pub struct ELFSection {
 
 /// An ELF symbol
 #[repr(packed)]
-pub struct ELFSymbol {
+pub struct ElfSymbol {
     pub name: ElfWord,
     pub value: ElfAddr,
     pub size: ElfWord,

--- a/kernel/common/elf_arch-x86_64.rs
+++ b/kernel/common/elf_arch-x86_64.rs
@@ -7,7 +7,7 @@ pub type ElfXword = u64;
 
 /// An ELF header
 #[repr(packed)]
-pub struct ELFHeader {
+pub struct ElfHeader {
     /// The "magic number" (4 bytes)
     pub magic: [u8; 4],
     /// 64 or 32 bit?
@@ -50,7 +50,7 @@ pub struct ELFHeader {
 
 /// An ELF segment
 #[repr(packed)]
-pub struct ELFSegment {
+pub struct ElfSegment {
     pub _type: ElfWord,
     pub flags: ElfWord,
     pub off: ElfOff,
@@ -63,7 +63,7 @@ pub struct ELFSegment {
 
 /// An ELF section
 #[repr(packed)]
-pub struct ELFSection {
+pub struct ElfSection {
     pub name: ElfWord,
     pub _type: ElfWord,
     pub flags: ElfXword,
@@ -78,7 +78,7 @@ pub struct ELFSection {
 
 /// An ELF symbol
 #[repr(packed)]
-pub struct ELFSymbol {
+pub struct ElfSymbol {
     pub name: ElfWord,
     pub info: u8,
     pub other: u8,

--- a/kernel/drivers/disk.rs
+++ b/kernel/drivers/disk.rs
@@ -57,21 +57,21 @@ const PRD_EOT: u32 = 0x80000000;
 
 /// Physical Region Descriptor
 #[repr(packed)]
-struct PRD {
+struct Prd {
     addr: u32,
     size: u32,
 }
 
-struct PRDT {
-    reg: PIO32,
-    mem: Memory<PRD>,
+struct Prdt {
+    reg: Pio32,
+    mem: Memory<Prd>,
 }
 
-impl PRDT {
+impl Prdt {
     fn new(port: u16) -> Option<Self> {
         if let Some(mem) = Memory::new_align(8192, 65536) {
-            return Some(PRDT {
-                reg: PIO32::new(port),
+            return Some(Prdt {
+                reg: Pio32::new(port),
                 mem: mem,
             });
         }
@@ -80,7 +80,7 @@ impl PRDT {
     }
 }
 
-impl Drop for PRDT {
+impl Drop for Prdt {
     fn drop(&mut self) {
         unsafe { self.reg.write(0) };
     }
@@ -169,9 +169,9 @@ pub struct Disk {
     master: bool,
     request: Option<Request>,
     requests: Queue<Request>,
-    cmd: PIO8,
-    sts: PIO8,
-    prdt: Option<PRDT>,
+    cmd: Pio8,
+    sts: Pio8,
+    prdt: Option<Prdt>,
     pub irq: u8,
 }
 
@@ -184,9 +184,9 @@ impl Disk {
             master: true,
             request: None,
             requests: Queue::new(),
-            cmd: PIO8::new(base),
-            sts: PIO8::new(base + 2),
-            prdt: PRDT::new(base + 4),
+            cmd: Pio8::new(base),
+            sts: Pio8::new(base + 2),
+            prdt: Prdt::new(base + 4),
             irq: 0xE,
         }
     }
@@ -199,9 +199,9 @@ impl Disk {
             master: false,
             request: None,
             requests: Queue::new(),
-            cmd: PIO8::new(base),
-            sts: PIO8::new(base + 2),
-            prdt: PRDT::new(base + 4),
+            cmd: Pio8::new(base),
+            sts: Pio8::new(base + 2),
+            prdt: Prdt::new(base + 4),
             irq: 0xE,
         }
     }
@@ -214,9 +214,9 @@ impl Disk {
             master: true,
             request: None,
             requests: Queue::new(),
-            cmd: PIO8::new(base + 8),
-            sts: PIO8::new(base + 0xA),
-            prdt: PRDT::new(base + 0xC),
+            cmd: Pio8::new(base + 8),
+            sts: Pio8::new(base + 0xA),
+            prdt: Prdt::new(base + 0xC),
             irq: 0xF,
         }
     }
@@ -229,9 +229,9 @@ impl Disk {
             master: false,
             request: None,
             requests: Queue::new(),
-            cmd: PIO8::new(base + 8),
-            sts: PIO8::new(base + 0xA),
-            prdt: PRDT::new(base + 0xC),
+            cmd: Pio8::new(base + 8),
+            sts: Pio8::new(base + 0xA),
+            prdt: Prdt::new(base + 0xC),
             irq: 0xF,
         }
     }
@@ -327,7 +327,7 @@ impl Disk {
             return false;
         }
 
-        let data = PIO16::new(self.base + ATA_REG_DATA);
+        let data = Pio16::new(self.base + ATA_REG_DATA);
         let mut destination = Memory::<u16>::new(256).unwrap();
         for word in 0..256 {
             destination.write(word, data.read());
@@ -486,7 +486,7 @@ impl Disk {
                         }
 
                         prdt.mem.store(i,
-                                       PRD {
+                                       Prd {
                                            addr: (req.mem + i * 65536) as u32,
                                            size: eot,
                                        });
@@ -496,7 +496,7 @@ impl Disk {
                     }
                     if size > 0 && i < 8192 {
                         prdt.mem.store(i,
-                                       PRD {
+                                       Prd {
                                            addr: (req.mem + i * 65536) as u32,
                                            size: size as u32 | PRD_EOT,
                                        });

--- a/kernel/drivers/mmio.rs
+++ b/kernel/drivers/mmio.rs
@@ -1,12 +1,12 @@
 use core::intrinsics::{volatile_load, volatile_store};
 
-pub struct MMIO<T> {
+pub struct Mmio<T> {
     address: *mut T,
 }
 
-impl <T> MMIO <T> {
+impl <T> Mmio <T> {
     fn new(address: *mut T) -> Self {
-        return MMIO { address: address };
+        return Mmio { address: address };
     }
 
     unsafe fn read(&self) -> T {

--- a/kernel/drivers/pciconfig.rs
+++ b/kernel/drivers/pciconfig.rs
@@ -2,24 +2,24 @@ use drivers::pio::*;
 
 /// A PCI configuration
 #[derive(Copy, Clone)]
-pub struct PCIConfig {
+pub struct PciConfig {
     bus: u8,
     slot: u8,
     func: u8,
-    addr: PIO32,
-    data: PIO32,
+    addr: Pio32,
+    data: Pio32,
 }
 
-impl PCIConfig {
+impl PciConfig {
     /// Create a new configuration
     pub fn new(bus: u8, slot: u8, func: u8) -> Self {
-        return PCIConfig {
+        PciConfig {
             bus: bus,
             slot: slot,
             func: func,
-            addr: PIO32::new(0xCF8),
-            data: PIO32::new(0xCFC),
-        };
+            addr: Pio32::new(0xCF8),
+            data: Pio32::new(0xCFC),
+        }
     }
 
     fn address(&self, offset: u8) -> u32 {

--- a/kernel/drivers/pio.rs
+++ b/kernel/drivers/pio.rs
@@ -1,13 +1,13 @@
 /// PIO8
 #[derive(Copy, Clone)]
-pub struct PIO8 {
+pub struct Pio8 {
     port: u16,
 }
 
-impl PIO8 {
+impl Pio8 {
     /// Create a PIO8 from a given port
     pub fn new(port: u16) -> Self {
-        return PIO8 { port: port };
+        return Pio8 { port: port };
     }
 
     /// Read
@@ -25,24 +25,24 @@ impl PIO8 {
 
 //TODO: Remove
 pub unsafe fn inb(port: u16) -> u8 {
-    return PIO8::new(port).read();
+    return Pio8::new(port).read();
 }
 
 //TODO: Remove
 pub unsafe fn outb(port: u16, value: u8) {
-    PIO8::new(port).write(value);
+    Pio8::new(port).write(value);
 }
 
 /// PIO16
 #[derive(Copy, Clone)]
-pub struct PIO16 {
+pub struct Pio16 {
     port: u16,
 }
 
-impl PIO16 {
+impl Pio16 {
     /// Create a new PIO16 from a given port
     pub fn new(port: u16) -> Self {
-        return PIO16 { port: port };
+        return Pio16 { port: port };
     }
 
     /// Read
@@ -60,24 +60,24 @@ impl PIO16 {
 
 //TODO: Remove
 pub unsafe fn inw(port: u16) -> u16 {
-    return PIO16::new(port).read();
+    return Pio16::new(port).read();
 }
 
 //TODO: Remove
 pub unsafe fn outw(port: u16, value: u16) {
-    PIO16::new(port).write(value);
+    Pio16::new(port).write(value);
 }
 
 /// PIO32
 #[derive(Copy, Clone)]
-pub struct PIO32 {
+pub struct Pio32 {
     port: u16,
 }
 
-impl PIO32 {
+impl Pio32 {
     /// Create a new PIO32 from a port
     pub fn new(port: u16) -> Self {
-        return PIO32 { port: port };
+        return Pio32 { port: port };
     }
 
     /// Read
@@ -95,10 +95,10 @@ impl PIO32 {
 
 //TODO: Remove
 pub unsafe fn ind(port: u16) -> u32 {
-    return PIO32::new(port).read();
+    return Pio32::new(port).read();
 }
 
 //TODO: Remove
 pub unsafe fn outd(port: u16, value: u32) {
-    PIO32::new(port).write(value);
+    Pio32::new(port).write(value);
 }

--- a/kernel/drivers/ps2.rs
+++ b/kernel/drivers/ps2.rs
@@ -7,11 +7,11 @@ use drivers::pio::*;
 use schemes::KScheme;
 
 /// PS2
-pub struct PS2 {
+pub struct Ps2 {
     /// The data
-    data: PIO8,
+    data: Pio8,
     /// The command
-    cmd: PIO8,
+    cmd: Pio8,
     /// Left shift?
     lshift: bool,
     /// Right shift?
@@ -26,12 +26,12 @@ pub struct PS2 {
     mouse_i: usize,
 }
 
-impl PS2 {
+impl Ps2 {
     /// Create new PS2 data
     pub fn new() -> Box<Self> {
-        let mut module = box PS2 {
-            data: PIO8::new(0x60),
-            cmd: PIO8::new(0x64),
+        let mut module = box Ps2 {
+            data: Pio8::new(0x60),
+            cmd: Pio8::new(0x64),
             lshift: false,
             rshift: false,
             caps_lock: false,
@@ -222,7 +222,7 @@ impl PS2 {
     }
 }
 
-impl KScheme for PS2 {
+impl KScheme for Ps2 {
     fn on_irq(&mut self, irq: u8) {
         if irq == 0x1 || irq == 0xC {
             self.on_poll();

--- a/kernel/drivers/rtc.rs
+++ b/kernel/drivers/rtc.rs
@@ -8,17 +8,17 @@ fn cvt_bcd(value: usize) -> usize {
 }
 
 /// RTC
-pub struct RTC {
-    addr: PIO8,
-    data: PIO8,
+pub struct Rtc {
+    addr: Pio8,
+    data: Pio8,
 }
 
-impl RTC {
+impl Rtc {
     /// Create new empty RTC
     pub fn new() -> Self {
-        return RTC {
-            addr: PIO8::new(0x70),
-            data: PIO8::new(0x71),
+        return Rtc {
+            addr: Pio8::new(0x70),
+            data: Pio8::new(0x71),
         }
     }
 

--- a/kernel/drivers/serial.rs
+++ b/kernel/drivers/serial.rs
@@ -8,8 +8,8 @@ use schemes::KScheme;
 
 /// Serial
 pub struct Serial {
-    pub data: PIO8,
-    pub status: PIO8,
+    pub data: Pio8,
+    pub status: Pio8,
     pub irq: u8,
     pub escape: bool,
     pub cursor_control: bool,
@@ -19,8 +19,8 @@ impl Serial {
     /// Create new
     pub fn new(port: u16, irq: u8) -> Box<Self> {
         box Serial {
-            data: PIO8::new(port),
-            status: PIO8::new(port + 5),
+            data: Pio8::new(port),
+            status: Pio8::new(port + 5),
             irq: irq,
             escape: false,
             cursor_control: false,
@@ -76,7 +76,7 @@ impl KScheme for Serial {
                     scancode: sc,
                     pressed: true,
                 }
-                    .trigger();
+                .trigger();
             }
         }
     }

--- a/kernel/graphics/bmp.rs
+++ b/kernel/graphics/bmp.rs
@@ -10,17 +10,17 @@ use super::size::Size;
 
 // TODO: Follow naming convention
 /// A bitmap
-pub struct BMPFile {
+pub struct BmpFile {
     /// The data of the bitmap
     pub data: Vec<u32>,
     /// The bitmap size
     pub size: Size,
 }
 
-impl BMPFile {
+impl BmpFile {
     /// Create a new empty bitmap
     pub fn new() -> Self {
-        BMPFile {
+        BmpFile {
             data: Vec::new(),
             size: Size {
                 width: 0,
@@ -31,7 +31,7 @@ impl BMPFile {
 
     /// Create a bitmap from some data
     pub fn from_data(file_data: &Vec<u8>) -> Self {
-        let mut ret = BMPFile::new();
+        let mut ret = BmpFile::new();
 
         let get = |i: usize| -> u8 {
             match file_data.get(i) {

--- a/kernel/network/common.rs
+++ b/kernel/network/common.rs
@@ -57,11 +57,11 @@ impl n32 {
 }
 
 #[derive(Copy, Clone)]
-pub struct MACAddr {
+pub struct MacAddr {
     pub bytes: [u8; 6],
 }
 
-impl MACAddr {
+impl MacAddr {
     pub fn equals(&self, other: Self) -> bool {
         for i in 0..6 {
             if self.bytes[i] != other.bytes[i] {
@@ -72,7 +72,7 @@ impl MACAddr {
     }
 
     pub fn from_string(string: &String) -> Self {
-        let mut addr = MACAddr { bytes: [0, 0, 0, 0, 0, 0] };
+        let mut addr = MacAddr { bytes: [0, 0, 0, 0, 0, 0] };
 
         let mut i = 0;
         for part in string.split('.') {
@@ -104,16 +104,16 @@ impl MACAddr {
     }
 }
 
-pub static BROADCAST_MAC_ADDR: MACAddr = MACAddr { bytes: [0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF] };
+pub static BROADCAST_MAC_ADDR: MacAddr = MacAddr { bytes: [0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF] };
 
-pub static mut MAC_ADDR: MACAddr = MACAddr { bytes: [0x00, 0x00, 0x00, 0x00, 0x00, 0x00] };
+pub static mut MAC_ADDR: MacAddr = MacAddr { bytes: [0x00, 0x00, 0x00, 0x00, 0x00, 0x00] };
 
 #[derive(Copy, Clone)]
-pub struct IPv4Addr {
+pub struct Ipv4Addr {
     pub bytes: [u8; 4],
 }
 
-impl IPv4Addr {
+impl Ipv4Addr {
     pub fn equals(&self, other: Self) -> bool {
         for i in 0..4 {
             if self.bytes[i] != other.bytes[i] {
@@ -124,7 +124,7 @@ impl IPv4Addr {
     }
 
     pub fn from_string(string: &String) -> Self {
-        let mut addr = IPv4Addr { bytes: [0, 0, 0, 0] };
+        let mut addr = Ipv4Addr { bytes: [0, 0, 0, 0] };
 
         let mut i = 0;
         for part in string.split('.') {
@@ -157,11 +157,11 @@ impl IPv4Addr {
 }
 
 #[derive(Copy, Clone)]
-pub struct IPv6Addr {
+pub struct Ipv6Addr {
     pub bytes: [u8; 16],
 }
 
-impl IPv6Addr {
+impl Ipv6Addr {
     pub fn to_string(&self) -> String {
         let mut string = String::new();
 
@@ -176,9 +176,9 @@ impl IPv6Addr {
     }
 }
 
-pub static BROADCAST_IP_ADDR: IPv4Addr = IPv4Addr { bytes: [10, 85, 85, 255] };
+pub static BROADCAST_IP_ADDR: Ipv4Addr = Ipv4Addr { bytes: [10, 85, 85, 255] };
 
-pub static IP_ADDR: IPv4Addr = IPv4Addr { bytes: [10, 85, 85, 2] };
+pub static IP_ADDR: Ipv4Addr = Ipv4Addr { bytes: [10, 85, 85, 2] };
 
 #[derive(Copy, Clone)]
 pub struct Checksum {

--- a/kernel/network/ethernet.rs
+++ b/kernel/network/ethernet.rs
@@ -8,8 +8,8 @@ use network::common::*;
 #[derive(Copy, Clone)]
 #[repr(packed)]
 pub struct EthernetIIHeader {
-    pub dst: MACAddr,
-    pub src: MACAddr,
+    pub dst: MacAddr,
+    pub src: MacAddr,
     pub ethertype: n16,
 }
 

--- a/kernel/network/ipv4.rs
+++ b/kernel/network/ipv4.rs
@@ -7,7 +7,7 @@ use network::common::*;
 
 #[derive(Copy, Clone)]
 #[repr(packed)]
-pub struct IPv4Header {
+pub struct Ipv4Header {
     pub ver_hlen: u8,
     pub services: u8,
     pub len: n16,
@@ -16,26 +16,26 @@ pub struct IPv4Header {
     pub ttl: u8,
     pub proto: u8,
     pub checksum: Checksum,
-    pub src: IPv4Addr,
-    pub dst: IPv4Addr,
+    pub src: Ipv4Addr,
+    pub dst: Ipv4Addr,
 }
 
-pub struct IPv4 {
-    pub header: IPv4Header,
+pub struct Ipv4 {
+    pub header: Ipv4Header,
     pub options: Vec<u8>,
     pub data: Vec<u8>,
 }
 
-impl FromBytes for IPv4 {
+impl FromBytes for Ipv4 {
     fn from_bytes(bytes: Vec<u8>) -> Option<Self> {
-        if bytes.len() >= mem::size_of::<IPv4Header>() {
+        if bytes.len() >= mem::size_of::<Ipv4Header>() {
             unsafe {
-                let header = *(bytes.as_ptr() as *const IPv4Header);
+                let header = *(bytes.as_ptr() as *const Ipv4Header);
                 let header_len = ((header.ver_hlen & 0xF) << 2) as usize;
 
-                return Some(IPv4 {
+                return Some(Ipv4 {
                     header: header,
-                    options: bytes[mem::size_of::<IPv4Header>() .. header_len].to_vec(),
+                    options: bytes[mem::size_of::<Ipv4Header>() .. header_len].to_vec(),
                     data: bytes[header_len ..].to_vec(),
                 });
             }
@@ -44,11 +44,11 @@ impl FromBytes for IPv4 {
     }
 }
 
-impl ToBytes for IPv4 {
+impl ToBytes for Ipv4 {
     fn to_bytes(&self) -> Vec<u8> {
         unsafe {
-            let header_ptr: *const IPv4Header = &self.header;
-            let mut ret = Vec::<u8>::from(slice::from_raw_parts(header_ptr as *const u8, mem::size_of::<IPv4Header>()));
+            let header_ptr: *const Ipv4Header = &self.header;
+            let mut ret = Vec::<u8>::from(slice::from_raw_parts(header_ptr as *const u8, mem::size_of::<Ipv4Header>()));
             ret.push_all(&self.options);
             ret.push_all(&self.data);
             ret

--- a/kernel/network/ipv6.rs
+++ b/kernel/network/ipv6.rs
@@ -3,11 +3,11 @@
 use network::common::*;
 
 #[derive(Copy, Clone)]
-pub struct IPv6 {
+pub struct Ipv6 {
     pub version: n32, // also has traffic class and flow label, TODO
     pub len: n16,
     pub next_header: u8,
     pub hop_limit: u8,
-    pub src: IPv6Addr,
-    pub dst: IPv6Addr,
+    pub src: Ipv6Addr,
+    pub dst: Ipv6Addr,
 }

--- a/kernel/network/scheme.rs
+++ b/kernel/network/scheme.rs
@@ -9,7 +9,7 @@ use common::debug;
 use common::queue::Queue;
 use scheduler;
 
-use schemes::{Resource, ResourceSeek, URL};
+use schemes::{Resource, ResourceSeek, Url};
 
 pub trait NetworkScheme {
     fn add(&mut self, resource: *mut NetworkResource);
@@ -61,8 +61,8 @@ impl Resource for NetworkResource {
         Some(ret)
     }
 
-    fn url(&self) -> URL {
-        URL::from_str("network://")
+    fn url(&self) -> Url {
+        Url::from_str("network://")
     }
 
     fn read(&mut self, buf: &mut [u8]) -> Option<usize> {

--- a/kernel/programs/executor.rs
+++ b/kernel/programs/executor.rs
@@ -3,15 +3,15 @@ use collections::vec::Vec;
 
 use scheduler::context::{self, Context, ContextFile, ContextMemory};
 use common::debug;
-use common::elf::ELF;
+use common::elf::Elf;
 use common::memory;
 use scheduler;
 use collections::string::ToString;
 
-use schemes::URL;
+use schemes::Url;
 
 /// Excecute an excecutable
-pub fn execute(url: &URL, wd: &URL, mut args: Vec<String>) {
+pub fn execute(url: &Url, wd: &Url, mut args: Vec<String>) {
     debug::d("Execute ");
     debug::d(&url.to_string());
     debug::d(" in ");
@@ -28,7 +28,7 @@ pub fn execute(url: &URL, wd: &URL, mut args: Vec<String>) {
             let mut vec: Vec<u8> = Vec::new();
             resource.read_to_end(&mut vec);
 
-            let executable = ELF::from_data(vec.as_ptr() as usize);
+            let executable = Elf::from_data(vec.as_ptr() as usize);
             if let Some(segment) = executable.load_segment() {
                 virtual_address = segment.vaddr as usize;
                 virtual_size = segment.mem_len as usize;
@@ -78,21 +78,21 @@ pub fn execute(url: &URL, wd: &URL, mut args: Vec<String>) {
 
             *context.args.get() = args;
 
-            if let Some(stdin) = URL::from_str("debug://").open() {
+            if let Some(stdin) = Url::from_str("debug://").open() {
                 (*context.files.get()).push(ContextFile {
                     fd: 0, // STDIN
                     resource: stdin,
                 });
             }
 
-            if let Some(stdout) = URL::from_str("debug://").open() {
+            if let Some(stdout) = Url::from_str("debug://").open() {
                 (*context.files.get()).push(ContextFile {
                     fd: 1, // STDOUT
                     resource: stdout,
                 });
             }
 
-            if let Some(stderr) = URL::from_str("debug://").open() {
+            if let Some(stderr) = Url::from_str("debug://").open() {
                 (*context.files.get()).push(ContextFile {
                     fd: 2, // STDERR
                     resource: stderr,

--- a/kernel/programs/package.rs
+++ b/kernel/programs/package.rs
@@ -6,22 +6,22 @@ use collections::vec::Vec;
 use common::debug;
 use common::parse_path::parse_path;
 
-use graphics::bmp::BMPFile;
+use graphics::bmp::BmpFile;
 
-use schemes::URL;
+use schemes::Url;
 
 /// A package (_REDOX content serialized)
 pub struct Package {
     /// The URL
-    pub url: URL,
+    pub url: Url,
     /// The ID of the package
     pub id: String,
     /// The name of the package
     pub name: String,
     /// The binary for the package
-    pub binary: URL,
+    pub binary: Url,
     /// The icon for the package
-    pub icon: BMPFile,
+    pub icon: BmpFile,
     /// The accepted extensions
     pub accepts: Vec<String>,
     /// The author(s) of the package
@@ -32,13 +32,13 @@ pub struct Package {
 
 impl Package {
     /// Create package from URL
-    pub fn from_url(url: &URL) -> Box<Self> {
+    pub fn from_url(url: &Url) -> Box<Self> {
         let mut package = box Package {
             url: url.clone(),
             id: String::new(),
             name: String::new(),
-            binary: URL::new(),
-            icon: BMPFile::new(),
+            binary: Url::new(),
+            icon: BmpFile::new(),
             accepts: Vec::new(),
             authors: Vec::new(),
             descriptions: Vec::new(),
@@ -49,13 +49,13 @@ impl Package {
         if !path_parts.is_empty() {
             if let Some(part) = path_parts.get(path_parts.len() - 1) {
                 package.id = part.clone();
-                package.binary = URL::from_string(&(url.to_string() + part + ".bin"));
+                package.binary = Url::from_string(&(url.to_string() + part + ".bin"));
             }
         }
 
         let mut info = String::new();
 
-        if let Some(mut resource) = URL::from_string(&(url.to_string() + "_REDOX")).open() {
+        if let Some(mut resource) = Url::from_string(&(url.to_string() + "_REDOX")).open() {
             resource.read_to_end(unsafe { info.as_mut_vec() });
         }
 
@@ -63,12 +63,12 @@ impl Package {
             if line.starts_with("name=") {
                 package.name = line[5 ..].to_string();
             } else if line.starts_with("binary=") {
-                package.binary = URL::from_string(&(url.to_string() + &line[7 ..]));
+                package.binary = Url::from_string(&(url.to_string() + &line[7 ..]));
             } else if line.starts_with("icon=") {
-                if let Some(mut resource) = URL::from_string(&line[5 ..].to_string()).open() {
+                if let Some(mut resource) = Url::from_string(&line[5 ..].to_string()).open() {
                     let mut vec: Vec<u8> = Vec::new();
                     resource.read_to_end(&mut vec);
-                    package.icon = BMPFile::from_data(&vec);
+                    package.icon = BmpFile::from_data(&vec);
                 }
             } else if line.starts_with("accept=") {
                 package.accepts.push(line[7 ..].to_string());

--- a/kernel/programs/session.rs
+++ b/kernel/programs/session.rs
@@ -9,7 +9,7 @@ use collections::vec::Vec;
 use common::event::{Event, EventOption, KeyEvent, MouseEvent};
 use scheduler;
 
-use graphics::bmp::BMPFile;
+use graphics::bmp::BmpFile;
 use graphics::color::Color;
 use graphics::display::Display;
 use graphics::point::Point;
@@ -17,16 +17,16 @@ use graphics::size::Size;
 use graphics::window::Window;
 
 use schemes::KScheme;
-use schemes::{Resource, URL, VecResource};
+use schemes::{Resource, Url, VecResource};
 
 /// A session
 pub struct Session {
     /// The display
     pub display: Box<Display>,
     /// The background image
-    pub background: BMPFile,
+    pub background: BmpFile,
     /// The cursor icon
-    pub cursor: BMPFile,
+    pub cursor: BmpFile,
     /// The mouse point
     pub mouse_point: Point,
     last_mouse_event: MouseEvent,
@@ -48,8 +48,8 @@ impl Session {
         unsafe {
             box Session {
                 display: Display::root(),
-                background: BMPFile::new(),
-                cursor: BMPFile::new(),
+                background: BmpFile::new(),
+                cursor: BmpFile::new(),
                 mouse_point: Point::new(0, 0),
                 last_mouse_event: MouseEvent {
                     x: 0,
@@ -131,7 +131,7 @@ impl Session {
     }
 
     /// Open a new resource
-    pub fn open(&mut self, url: &URL) -> Option<Box<Resource>> {
+    pub fn open(&mut self, url: &Url) -> Option<Box<Resource>> {
         if url.scheme().len() == 0 {
             let mut list = String::new();
 
@@ -146,7 +146,7 @@ impl Session {
                 }
             }
 
-            Some(box VecResource::new(URL::new(), list.into_bytes()))
+            Some(box VecResource::new(Url::new(), list.into_bytes()))
         } else {
             for mut item in self.items.iter_mut() {
                 if item.scheme() == url.scheme() {

--- a/kernel/schemes/context.rs
+++ b/kernel/schemes/context.rs
@@ -3,7 +3,7 @@ use alloc::boxed::Box;
 use scheduler::context;
 use scheduler;
 
-use schemes::{KScheme, Resource, URL, VecResource};
+use schemes::{KScheme, Resource, Url, VecResource};
 
 pub struct ContextScheme;
 
@@ -12,7 +12,7 @@ impl KScheme for ContextScheme {
         "context"
     }
 
-    fn open(&mut self, _: &URL) -> Option<Box<Resource>> {
+    fn open(&mut self, _: &Url) -> Option<Box<Resource>> {
         let i;
         let len;
         unsafe {
@@ -22,6 +22,6 @@ impl KScheme for ContextScheme {
             scheduler::end_no_ints(reenable);
         }
 
-        Some(box VecResource::new(URL::from_str("context://"), format!("Current: {}\nTotal: {}", i, len).into_bytes()))
+        Some(box VecResource::new(Url::from_str("context://"), format!("Current: {}\nTotal: {}", i, len).into_bytes()))
     }
 }

--- a/kernel/schemes/debug.rs
+++ b/kernel/schemes/debug.rs
@@ -3,7 +3,7 @@ use alloc::boxed::Box;
 use scheduler::context::recursive_unsafe_yield;
 use scheduler;
 
-use schemes::{KScheme, Resource, URL};
+use schemes::{KScheme, Resource, Url};
 
 use syscall::handle;
 
@@ -15,8 +15,8 @@ impl Resource for DebugResource {
         Some(box DebugResource)
     }
 
-    fn url(&self) -> URL {
-        return URL::from_str("debug://");
+    fn url(&self) -> Url {
+        return Url::from_str("debug://");
     }
 
     fn read(&mut self, buf: &mut [u8]) -> Option<usize> {
@@ -69,7 +69,7 @@ impl KScheme for DebugScheme {
         "debug"
     }
 
-    fn open(&mut self, _: &URL) -> Option<Box<Resource>> {
+    fn open(&mut self, _: &Url) -> Option<Box<Resource>> {
         Some(box DebugResource)
     }
 }

--- a/kernel/schemes/display.rs
+++ b/kernel/schemes/display.rs
@@ -6,7 +6,7 @@ use core::cmp;
 
 use graphics::display::Display;
 
-use schemes::{KScheme, Resource, ResourceSeek, URL};
+use schemes::{KScheme, Resource, ResourceSeek, Url};
 
 pub struct DisplayScheme;
 
@@ -21,8 +21,8 @@ pub struct DisplayResource {
 
 impl Resource for DisplayResource {
     /// Return the URL for display resource
-    fn url(&self) -> URL {
-        return URL::from_string(&("display://".to_string()));
+    fn url(&self) -> Url {
+        return Url::from_string(&("display://".to_string()));
     }
 
 
@@ -62,7 +62,7 @@ impl KScheme for DisplayScheme {
         "display"
     }
 
-    fn open(&mut self, _: &URL) -> Option<Box<Resource>> {
+    fn open(&mut self, _: &Url) -> Option<Box<Resource>> {
         // TODO: ponder these things:
         // - should display:// be the only only valid url
         //      for this scheme?

--- a/kernel/schemes/ethernet.rs
+++ b/kernel/schemes/ethernet.rs
@@ -12,7 +12,7 @@ use common::parse_ip::*;
 use network::common::*;
 use network::ethernet::*;
 
-use schemes::{KScheme, Resource, URL};
+use schemes::{KScheme, Resource, Url};
 
 /// A ethernet resource
 pub struct EthernetResource {
@@ -21,7 +21,7 @@ pub struct EthernetResource {
     /// The data
     data: Vec<u8>,
     /// The MAC addresss
-    peer_addr: MACAddr,
+    peer_addr: MacAddr,
     /// The ethernet type
     ethertype: u16,
 }
@@ -39,8 +39,8 @@ impl Resource for EthernetResource {
         }
     }
 
-    fn url(&self) -> URL {
-        URL::from_string(&format!("ethernet://{}/{:X}", self.peer_addr.to_string(), self.ethertype))
+    fn url(&self) -> Url {
+        Url::from_string(&format!("ethernet://{}/{:X}", self.peer_addr.to_string(), self.ethertype))
     }
 
     fn read(&mut self, _: &mut [u8]) -> Option<usize> {
@@ -104,8 +104,8 @@ impl KScheme for EthernetScheme {
         "ethernet"
     }
 
-    fn open(&mut self, url: &URL) -> Option<Box<Resource>> {
-        if let Some(mut network) = URL::from_str("network://").open() {
+    fn open(&mut self, url: &Url) -> Option<Box<Resource>> {
+        if let Some(mut network) = Url::from_str("network://").open() {
             if !url.reference().is_empty() {
                 let ethertype = url.reference().to_num_radix(16) as u16;
 
@@ -113,7 +113,7 @@ impl KScheme for EthernetScheme {
                     return Some(box EthernetResource {
                         network: network,
                         data: Vec::new(),
-                        peer_addr: MACAddr::from_string(&parse_host(url.reference()).to_string()),
+                        peer_addr: MacAddr::from_string(&parse_host(url.reference()).to_string()),
                         ethertype: ethertype,
                     });
                 } else {

--- a/kernel/schemes/file.rs
+++ b/kernel/schemes/file.rs
@@ -10,14 +10,14 @@ use core::{cmp, mem};
 use core::sync::atomic::{AtomicBool, Ordering};
 
 use drivers::disk::{Disk, Extent, Request};
-use drivers::pciconfig::PCIConfig;
+use drivers::pciconfig::PciConfig;
 
 use scheduler::context::recursive_unsafe_yield;
 use common::debug;
 use common::memory::Memory;
 use common::parse_path::*;
 
-use schemes::{KScheme, Resource, ResourceSeek, URL, VecResource};
+use schemes::{KScheme, Resource, ResourceSeek, Url, VecResource};
 
 /// The header of the fs
 #[repr(packed)]
@@ -251,8 +251,8 @@ impl Resource for FileResource {
         })
     }
 
-    fn url(&self) -> URL {
-        return URL::from_string(&("file:///".to_string() + &self.node.name));
+    fn url(&self) -> Url {
+        return Url::from_string(&("file:///".to_string() + &self.node.name));
     }
 
     fn read(&mut self, buf: &mut [u8]) -> Option<usize> {
@@ -440,14 +440,14 @@ impl Drop for FileResource {
 
 /// A file scheme (pci + fs)
 pub struct FileScheme {
-    pci: PCIConfig,
+    pci: PciConfig,
     fs: FileSystem,
 }
 
 impl FileScheme {
     ///TODO Allow busmaster for secondary
     /// Create a new file scheme from a PCI configuration
-    pub fn new(mut pci: PCIConfig) -> Option<Box<Self>> {
+    pub fn new(mut pci: PciConfig) -> Option<Box<Self>> {
         unsafe { pci.flag(4, 4, true) }; // Bus mastering
 
         let base = unsafe { pci.read(0x20) } as u16 & 0xFFF0;
@@ -509,7 +509,7 @@ impl KScheme for FileScheme {
         "file"
     }
 
-    fn open(&mut self, url: &URL) -> Option<Box<Resource>> {
+    fn open(&mut self, url: &Url) -> Option<Box<Resource>> {
         let path = url.reference();
         if path.is_empty() || path.ends_with('/') {
             let mut list = String::new();

--- a/kernel/schemes/memory.rs
+++ b/kernel/schemes/memory.rs
@@ -2,7 +2,7 @@ use alloc::boxed::Box;
 
 use common::memory;
 
-use schemes::{KScheme, Resource, URL, VecResource};
+use schemes::{KScheme, Resource, Url, VecResource};
 
 /// A memory scheme
 pub struct MemoryScheme;
@@ -12,8 +12,8 @@ impl KScheme for MemoryScheme {
         "memory"
     }
 
-    fn open(&mut self, _: &URL) -> Option<Box<Resource>> {
+    fn open(&mut self, _: &Url) -> Option<Box<Resource>> {
         let string = format!("Memory Used: {} KB\nMemory Free: {} KB", memory::memory_used() / 1024, memory::memory_free() / 1024);
-        Some(box VecResource::new(URL::from_str("memory://"), string.into_bytes()))
+        Some(box VecResource::new(Url::from_str("memory://"), string.into_bytes()))
     }
 }

--- a/kernel/schemes/mod.rs
+++ b/kernel/schemes/mod.rs
@@ -44,7 +44,7 @@ pub trait KScheme {
         ""
     }
 
-    fn open(&mut self, url: &URL) -> Option<Box<Resource>> {
+    fn open(&mut self, url: &Url) -> Option<Box<Resource>> {
         None
     }
 }
@@ -67,7 +67,7 @@ pub trait Resource {
         None
     }
     /// Return the url of this resource
-    fn url(&self) -> URL;
+    fn url(&self) -> Url;
     // TODO: Make use of Write and Read trait
     /// Read data to buffer
     fn read(&mut self, buf: &mut [u8]) -> Option<usize> {
@@ -108,24 +108,24 @@ pub trait Resource {
 }
 
 /// An URL, see wiki
-pub struct URL {
+pub struct Url {
     pub string: String,
 }
 
-impl URL {
+impl Url {
     /// Create a new empty URL
     pub fn new() -> Self {
-        URL { string: String::new() }
+        Url { string: String::new() }
     }
 
     /// Create an URL from a string literal
     pub fn from_str(url_str: &'static str) -> Self {
-        return URL::from_string(&url_str.to_string());
+        return Url::from_string(&url_str.to_string());
     }
 
     /// Create an URL from `String`
     pub fn from_string(url_string: &String) -> Self {
-        URL { string: url_string.clone() }
+        Url { string: url_string.clone() }
     }
 
     /// Convert to string
@@ -162,21 +162,21 @@ impl URL {
 
 }
 
-impl Clone for URL {
+impl Clone for Url {
     fn clone(&self) -> Self {
-        URL { string: self.string.clone() }
+        Url { string: self.string.clone() }
     }
 }
 
 /// A vector resource
 pub struct VecResource {
-    url: URL,
+    url: Url,
     vec: Vec<u8>,
     seek: usize,
 }
 
 impl VecResource {
-    pub fn new(url: URL, vec: Vec<u8>) -> Self {
+    pub fn new(url: Url, vec: Vec<u8>) -> Self {
         VecResource {
             url: url,
             vec: vec,
@@ -198,7 +198,7 @@ impl Resource for VecResource {
         })
     }
 
-    fn url(&self) -> URL {
+    fn url(&self) -> Url {
         return self.url.clone();
     }
 

--- a/kernel/schemes/random.rs
+++ b/kernel/schemes/random.rs
@@ -2,7 +2,7 @@ use alloc::boxed::Box;
 
 use common::random;
 
-use schemes::{KScheme, Resource, URL, VecResource};
+use schemes::{KScheme, Resource, Url, VecResource};
 
 /// A pseudorandomness scheme
 pub struct RandomScheme;
@@ -12,7 +12,7 @@ impl KScheme for RandomScheme {
         "random"
     }
 
-    fn open(&mut self, _: &URL) -> Option<Box<Resource>> {
-        Some(box VecResource::new(URL::from_str("random://"), format!("{}", random::rand()).into_bytes()))
+    fn open(&mut self, _: &Url) -> Option<Box<Resource>> {
+        Some(box VecResource::new(Url::from_str("random://"), format!("{}", random::rand()).into_bytes()))
     }
 }

--- a/kernel/schemes/time.rs
+++ b/kernel/schemes/time.rs
@@ -2,7 +2,7 @@ use alloc::boxed::Box;
 
 use scheduler;
 
-use schemes::{KScheme, Resource, URL, VecResource};
+use schemes::{KScheme, Resource, Url, VecResource};
 
 /// A time scheme
 pub struct TimeScheme;
@@ -12,7 +12,7 @@ impl KScheme for TimeScheme {
         "time"
     }
 
-    fn open(&mut self, _: &URL) -> Option<Box<Resource>> {
+    fn open(&mut self, _: &Url) -> Option<Box<Resource>> {
         let clock_realtime;
         let clock_monotonic;
         unsafe {
@@ -23,6 +23,6 @@ impl KScheme for TimeScheme {
         }
 
         let string = format!("Time: {}\nUptime: {}", clock_realtime.secs as isize, clock_monotonic.secs as isize);
-        Some(box VecResource::new(URL::from_str("time://"), string.into_bytes()))
+        Some(box VecResource::new(Url::from_str("time://"), string.into_bytes()))
     }
 }

--- a/kernel/schemes/window.rs
+++ b/kernel/schemes/window.rs
@@ -13,7 +13,7 @@ use graphics::point::Point;
 use graphics::size::Size;
 use graphics::window::Window;
 
-use schemes::{KScheme, Resource, ResourceSeek, URL};
+use schemes::{KScheme, Resource, ResourceSeek, Url};
 
 /// A window scheme
 pub struct WindowScheme;
@@ -35,8 +35,8 @@ impl Resource for WindowResource {
     }
 
     /// Return the url of this resource
-    fn url(&self) -> URL {
-        return URL::from_string(&format!("window://{}/{}/{}/{}/{}",
+    fn url(&self) -> Url {
+        return Url::from_string(&format!("window://{}/{}/{}/{}/{}",
                                     self.window.point.x,
                                     self.window.point.y,
                                     self.window.size.width,
@@ -101,7 +101,7 @@ impl KScheme for WindowScheme {
         "window"
     }
 
-    fn open(&mut self, url: &URL) -> Option<Box<Resource>> {
+    fn open(&mut self, url: &Url) -> Option<Box<Resource>> {
         //window://host/path/path/path is the path type we're working with.
         let url_path = parse_path(url.reference());
         let pointx = match url_path.get(0) {

--- a/kernel/syscall/handle.rs
+++ b/kernel/syscall/handle.rs
@@ -17,7 +17,7 @@ use programs::executor::execute;
 use graphics::color::Color;
 use graphics::size::Size;
 
-use schemes::{Resource, ResourceSeek, URL};
+use schemes::{Resource, ResourceSeek, Url};
 
 use syscall::common::*;
 
@@ -60,10 +60,10 @@ pub unsafe fn do_sys_debug(byte: u8) {
         }
     }
 
-    let serial_status = PIO8::new(0x3F8 + 5);
+    let serial_status = Pio8::new(0x3F8 + 5);
     while serial_status.read() & 0x20 == 0 {}
 
-    let mut serial_data = PIO8::new(0x3F8);
+    let mut serial_data = Pio8::new(0x3F8);
     serial_data.write(byte);
 
     scheduler::end_no_ints(reenable);
@@ -276,9 +276,9 @@ pub unsafe fn do_sys_execve(path: *const u8) -> usize {
     let reenable = scheduler::start_no_ints();
 
     if path_str.ends_with(".bin") {
-        let path = URL::from_string(&path_str);
+        let path = Url::from_string(&path_str);
         let i = path_str.rfind('/').unwrap_or(0) + 1;
-        let wd = URL::from_string(&path_str[ .. i].to_string());
+        let wd = Url::from_string(&path_str[ .. i].to_string());
         execute(&path,
                 &wd,
                 Vec::new());
@@ -448,7 +448,7 @@ pub unsafe fn do_sys_open(path: *const u8) -> usize {
 
         scheduler::end_no_ints(reenable);
 
-        let resource_option = (*::session_ptr).open(&URL::from_string(&path_str));
+        let resource_option = (*::session_ptr).open(&Url::from_string(&path_str));
 
         scheduler::start_no_ints();
 

--- a/kernel/usb/ehci.rs
+++ b/kernel/usb/ehci.rs
@@ -2,12 +2,12 @@ use core::ptr::{read, write};
 
 use common::debug;
 
-use drivers::pciconfig::PCIConfig;
+use drivers::pciconfig::PciConfig;
 
 use schemes::KScheme;
 
 #[repr(packed)]
-struct SETUP {
+struct Setup {
     request_type: u8,
     request: u8,
     value: u16,
@@ -16,7 +16,7 @@ struct SETUP {
 }
 
 #[repr(packed)]
-struct QTD {
+struct Qtd {
     next: u32,
     next_alt: u32,
     token: u32,
@@ -29,17 +29,17 @@ struct QueueHead {
     characteristics: u32,
     capabilities: u32,
     qtd_ptr: u32,
-    qtd: QTD,
+    qtd: Qtd,
 }
 
-pub struct EHCI {
-    pub pci: PCIConfig,
+pub struct Ehci {
+    pub pci: PciConfig,
     pub base: usize,
     pub memory_mapped: bool,
     pub irq: u8,
 }
 
-impl KScheme for EHCI {
+impl KScheme for Ehci {
     #[allow(non_snake_case)]
     fn on_irq(&mut self, irq: u8) {
         if irq == self.irq {
@@ -69,7 +69,7 @@ impl KScheme for EHCI {
     }
 }
 
-impl EHCI {
+impl Ehci {
     #[allow(non_snake_case)]
     pub unsafe fn init(&mut self) {
         debug::d("EHCI on: ");
@@ -319,8 +319,8 @@ impl EHCI {
                     debug::dl();
 
                     /*
-                    let out_qtd = alloc(size_of::<QTD>()) as *mut QTD;
-                    ptr::write(out_qtd, QTD {
+                    let out_qtd = alloc(size_of::<Qtd>()) as *mut Qtd;
+                    ptr::write(out_qtd, Qtd {
                         next: 1,
                         next_alt: 1,
                         token: (1 << 31) | (0b11 << 10) | 0x80,
@@ -332,16 +332,16 @@ impl EHCI {
                         *in_data.offset(i) = 0;
                     }
 
-                    let in_qtd = alloc(size_of::<QTD>()) as *mut QTD;
-                    ptr::write(in_qtd, QTD {
+                    let in_qtd = alloc(size_of::<Qtd>()) as *mut Qtd;
+                    ptr::write(in_qtd, Qtd {
                         next: out_qtd as u32,
                         next_alt: 1,
                         token: (1 << 31) | (64 << 16) | (0b11 << 10) | (0b01 << 8) | 0x80,
                         buffers: [in_data as u32, 0, 0, 0, 0]
                     });
 
-                    let setup_packet = alloc(size_of::<SETUP>()) as *mut SETUP;
-                    ptr::write(setup_packet, SETUP {
+                    let setup_packet = alloc(size_of::<Setup>()) as *mut Setup;
+                    ptr::write(setup_packet, Setup {
                         request_type: 0b10000000,
                         request: 6,
                         value: 1 << 8,
@@ -349,11 +349,11 @@ impl EHCI {
                         len: 64
                     });
 
-                    let setup_qtd = alloc(size_of::<QTD>()) as *mut QTD;
-                    ptr::write(setup_qtd, QTD {
+                    let setup_qtd = alloc(size_of::<Qtd>()) as *mut Qtd;
+                    ptr::write(setup_qtd, Qtd {
                         next: in_qtd as u32,
                         next_alt: 1,
-                        token: ((size_of::<SETUP>() as u32) << 16) | (0b11 << 10) | (0b10 << 8) | 0x80,
+                        token: ((size_of::<Setup>() as u32) << 16) | (0b11 << 10) | (0b10 << 8) | 0x80,
                         buffers: [setup_packet as u32, 0, 0, 0, 0]
                     });
 

--- a/kernel/usb/xhci.rs
+++ b/kernel/usb/xhci.rs
@@ -1,25 +1,25 @@
-use drivers::pciconfig::PCIConfig;
+use drivers::pciconfig::PciConfig;
 
 use common::debug;
 
 use schemes::KScheme;
 
 #[repr(packed)]
-struct STE {
+struct Ste {
     pub ptr: u64,
     pub length: u64,
 }
 
 #[repr(packed)]
-struct TRB {
+struct Trb {
     pub data: u64,
     pub status: u32,
     pub control: u32,
 }
 
-impl TRB {
+impl Trb {
     pub fn new() -> Self {
-        TRB {
+        Trb {
             data: 0,
             status: 0,
             control: 0,
@@ -27,7 +27,7 @@ impl TRB {
     }
 
     pub fn from_type(trb_type: u32) -> Self {
-        TRB {
+        Trb {
             data: 0,
             status: 0,
             control: (trb_type & 0x3F) << 10,
@@ -35,14 +35,14 @@ impl TRB {
     }
 }
 
-pub struct XHCI {
-    pub pci: PCIConfig,
+pub struct Xhci {
+    pub pci: PciConfig,
     pub base: usize,
     pub memory_mapped: bool,
     pub irq: u8,
 }
 
-impl KScheme for XHCI {
+impl KScheme for Xhci {
     fn on_irq(&mut self, irq: u8) {
         if irq == self.irq {
             debug::d("XHCI handle\n");
@@ -50,7 +50,7 @@ impl KScheme for XHCI {
     }
 }
 
-impl XHCI {
+impl Xhci {
     pub unsafe fn init(&self) {
         debug::d("XHCI on: ");
         debug::dh(self.base);

--- a/libredox/src/audio/wav.rs
+++ b/libredox/src/audio/wav.rs
@@ -3,7 +3,7 @@ use vec::Vec;
 
 /// A WAV file
 // TODO: Follow naming conventions
-pub struct WAV {
+pub struct WavFile {
     /// The number of channels
     pub channels: u16,
     /// The sample rate
@@ -14,10 +14,10 @@ pub struct WAV {
     pub data: Vec<u8>,
 }
 
-impl WAV {
+impl WavFile {
     /// Create a new empty WAV file
     pub fn new() -> Self {
-        WAV {
+        WavFile {
             channels: 0,
             sample_rate: 0,
             sample_bits: 0,
@@ -27,7 +27,7 @@ impl WAV {
 
     /// Create a WAV file from data
     pub fn from_data(file_data: &[u8]) -> Self {
-        let mut ret = WAV::new();
+        let mut ret = WavFile::new();
 
         let get = |i: usize| -> u8 {
             match file_data.get(i) {

--- a/libredox/src/graphics/bmp.rs
+++ b/libredox/src/graphics/bmp.rs
@@ -5,7 +5,7 @@ use vec::Vec;
 
 // TODO: Follow naming convention
 /// A bitmap
-pub struct BMPFile {
+pub struct BmpFile {
     /// The bitmap width
     w: usize,
     /// The bitmap height
@@ -15,10 +15,10 @@ pub struct BMPFile {
     data: Vec<Color>,
 }
 
-impl BMPFile {
+impl BmpFile {
     /// Create a new bitmap
     pub fn new(width: usize, height: usize) -> Self {
-        BMPFile {
+        BmpFile {
             w: width,
             h: height,
             data: Vec::new(),
@@ -50,7 +50,7 @@ impl BMPFile {
             (start..start + len).map(|i| get(i) as char).collect::<String>()
         };
 
-        let mut ret: BMPFile;
+        let mut ret: BmpFile;
 
         if gets(0, 2) == "BM" {
             //let file_size = getd(2);

--- a/libredox/src/url.rs
+++ b/libredox/src/url.rs
@@ -15,24 +15,24 @@ use vec::Vec;
             //Split the query by &
 
 /// An URL, see wiki
-pub struct URL {
+pub struct Url {
     pub string: String,
 }
 
-impl URL {
+impl Url {
     /// Create a new empty URL
     pub fn new() -> Self {
-        URL { string: String::new() }
+        Url { string: String::new() }
     }
 
     /// Create an URL from a string literal
     pub fn from_str(url_str: &&str) -> Self {
-        return URL::from_string(&url_str.to_string());
+        return Url::from_string(&url_str.to_string());
     }
 
     /// Create an URL from `String`
     pub fn from_string(url_string: &String) -> Self {
-        URL { string: url_string.clone() }
+        Url { string: url_string.clone() }
     }
 
     /// Convert to string
@@ -267,8 +267,8 @@ impl URL {
     }
 }
 
-impl Clone for URL {
+impl Clone for Url {
     fn clone(&self) -> Self {
-        URL { string: self.string.clone() }
+        Url { string: self.string.clone() }
     }
 }


### PR DESCRIPTION
Closes #61 