### PR TITLE
Add git submodule steps to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,13 @@ Sometimes things goes wrong when compiling. Try the following before opening an 
 
 and then rebuild!
 
+## Cloning the repository
+
+Make sure you get submodules when you clone the repository.
+```bash
+git clone --recursive
+```
+
 ## Building on Debian/Ubuntu
 - Run the setup script and enter your password when prompted (to install Rust compiler and its dependencies)
 ```bash


### PR DESCRIPTION
A recent change made the README setup instructions fail because rust is
not pulled as a submodule. This commit adds an additional step to the
setup documentation for each operating system indicating what to do to
fetch the submodule for rust. This change has only been tested on
Ubuntu.