### PR TITLE
Code cleanup

### DIFF
--- a/filesystem/apps/shell/main.rs
+++ b/filesystem/apps/shell/main.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::get_slice::GetSlice;
 use std::ops::DerefMut;
 use std::string::*;
@@ -31,6 +32,7 @@ static mut application: *mut Application<'static> = 0 as *mut Application;
 /// ```
 /// let my_command = Command {
 ///     name: "my_command",
+///     help: "Describe what my_command does followed by a newline showing usage",
 ///     main: box|args: &Vec<String>| {
 ///         println!("Say 'hello' to my command! :-D");
 ///     }
@@ -52,12 +54,7 @@ impl<'a> Command<'a> {
             name: "cat",
             help: "To display a file in the output\n    cat <your_file>",
             main: Box::new(|args: &Vec<String>| {
-                let path = {
-                    match args.get(1) {
-                        Some(arg) => arg.clone(),
-                        None => String::new(),
-                    }
-                };
+                let path = args.get(1).map_or(String::new(), |arg| arg.clone());
 
                 if let Some(mut file) = File::open(&path) {
                     let mut string = String::new();
@@ -152,12 +149,7 @@ impl<'a> Command<'a> {
             name: "ls",
             help: "To list the content of the current directory\n    ls",
             main: Box::new(|args: &Vec<String>| {
-                let path = {
-                    match args.get(1) {
-                        Some(arg) => arg.clone(),
-                        None => String::new(),
-                    }
-                };
+                let path = args.get(1).map_or(String::new(), |arg| arg.clone());
 
                 if let Some(dir) = read_dir(&path) {
                     for entry in dir {
@@ -241,21 +233,10 @@ impl<'a> Command<'a> {
             name: "sleep",
             help: "Make a sleep in the current session\n    sleep <number_of_seconds>",
             main: Box::new(|args: &Vec<String>| {
-                let secs = {
-                    match args.get(1) {
-                        Some(arg) => arg.to_num() as i64,
-                        None => 0,
-                    }
-                };
-
-                let nanos = {
-                    match args.get(2) {
-                        Some(arg) => arg.to_num() as i32,
-                        None => 0,
-                    }
-                };
-
+                let secs = args.get(1).map_or(0, |arg| arg.to_num() as i64);
+                let nanos = args.get(2).map_or(0, |arg| arg.to_num() as i32);
                 println!("Sleep: {} {}", secs, nanos);
+
                 let remaining = Duration::new(secs, nanos).sleep();
                 println!("Remaining: {} {}", remaining.secs, remaining.nanos);
             }),
@@ -271,12 +252,7 @@ impl<'a> Command<'a> {
                     return;
                 }
 
-                let path = {
-                    match args.get(1) {
-                        Some(arg) => arg.clone(),
-                        None => String::new(),
-                    }
-                };
+                let path = args.get(1).map_or(String::new(), |arg| arg.clone());
 
                 if let Some(mut file) = File::open(&path) {
                     println!("URL: {:?}", file.path());
@@ -320,12 +296,7 @@ impl<'a> Command<'a> {
             name: "url_hex",
             help: "",
             main: Box::new(|args: &Vec<String>| {
-                let path = {
-                    match args.get(1) {
-                        Some(arg) => arg.clone(),
-                        None => String::new(),
-                    }
-                };
+                let path = args.get(1).map_or(String::new(), |arg| arg.clone());
 
                 if let Some(mut file) = File::open(&path) {
                     let mut vec: Vec<u8> = Vec::new();
@@ -368,19 +339,20 @@ impl<'a> Command<'a> {
             }),
         });
 
-        let mut command_helper : HashMap<String, String> = HashMap::new();
-
-        for c in commands.iter() {
-            command_helper.insert(c.name.clone().to_string(), c.help.clone().to_string());
-        }
+        // TODO: Someone should implement FromIterator for HashMap before
+        //       changing the type back to HashMap
+        let mut command_helper: BTreeMap<String, String> = commands
+            .iter()
+            .map(|c| (c.name.to_string(), c.help.to_string()))
+            .collect();
 
         commands.push(Command {
             name: "man",
             help: "Display a little helper for a given command\n    man ls",
             main: Box::new(move |args: &Vec<String>| {
                 if let Some(command) = args.get(1) {
-                    if command_helper.contains_key(&command) {
-                        match command_helper.get(&command) {
+                    if command_helper.contains_key(command) {
+                        match command_helper.get(command) {
                             Some(help) => println!("{}", help),
                             None => println!("Command helper not found [run 'help']...")
                         }

--- a/filesystem/apps/zfs/arcache.rs
+++ b/filesystem/apps/zfs/arcache.rs
@@ -1,4 +1,3 @@
-use std::{Vec, String, ToString};
 use std::collections::{BTreeMap, VecDeque};
 
 use super::dvaddr::DVAddr;
@@ -78,7 +77,7 @@ impl Mfu {
 
         // Add the block to the cache
         self.used += dva.asize() as usize;
-        self.map.insert(*dva, (1, block));
+        self.map.insert(*dva, (2, block));
         Ok(self.map.get(dva).unwrap().1.clone())
     }
 }

--- a/filesystem/apps/zfs/avl.rs
+++ b/filesystem/apps/zfs/avl.rs
@@ -1,5 +1,3 @@
-use std::{Box, Vec};
-
 pub struct Node<T> {
     value: T,
     left: Option<usize>, // ID for left node

--- a/filesystem/apps/zfs/from_bytes.rs
+++ b/filesystem/apps/zfs/from_bytes.rs
@@ -1,4 +1,4 @@
-use std::*;
+use std::{mem, ptr};
 
 pub trait FromBytes: Sized {
     fn from_bytes(data: &[u8]) -> Result<Self, String> {

--- a/filesystem/apps/zfs/main.rs
+++ b/filesystem/apps/zfs/main.rs
@@ -1,5 +1,5 @@
 //To use this, please install zfs-fuse
-use std::*;
+use std::{mem, str, File, Read, ToNum};
 
 use self::arcache::ArCache;
 use self::dnode::{DNodePhys, ObjectSetPhys, ObjectType};

--- a/filesystem/apps/zfs/nvpair.rs
+++ b/filesystem/apps/zfs/nvpair.rs
@@ -1,4 +1,4 @@
-use std::*;
+use std::fmt;
 
 // nvp implementation version
 pub const NV_VERSION: i32 = 0;

--- a/filesystem/apps/zfs/nvstream.rs
+++ b/filesystem/apps/zfs/nvstream.rs
@@ -1,4 +1,4 @@
-use std::*;
+use std::mem;
 
 use super::nvpair::{DataType, NV_VERSION, NvList, NvValue};
 use super::xdr;

--- a/filesystem/apps/zfs/spa.rs
+++ b/filesystem/apps/zfs/spa.rs
@@ -1,5 +1,3 @@
-use std::{Box, String, ToString, Vec};
-
 use super::avl;
 use super::nvpair::{NvList, NvValue};
 use super::uberblock::Uberblock;

--- a/filesystem/apps/zfs/space_map.rs
+++ b/filesystem/apps/zfs/space_map.rs
@@ -1,4 +1,4 @@
-use std::{String, ToString, fmt};
+use std::fmt;
 
 use super::avl;
 use super::from_bytes::FromBytes;

--- a/filesystem/apps/zfs/uberblock.rs
+++ b/filesystem/apps/zfs/uberblock.rs
@@ -1,5 +1,4 @@
 use std::{mem, ptr};
-use std::{String, ToString};
 
 use super::from_bytes::FromBytes;
 use super::block_ptr::BlockPtr;

--- a/filesystem/apps/zfs/vdev.rs
+++ b/filesystem/apps/zfs/vdev.rs
@@ -1,5 +1,3 @@
-use std::{Box, String, ToString, Vec};
-
 use super::from_bytes::FromBytes;
 use super::metaslab::{Metaslab, MetaslabGroup};
 use super::nvpair::{NvList, NvValue};

--- a/filesystem/apps/zfs/vdev_file.rs
+++ b/filesystem/apps/zfs/vdev_file.rs
@@ -1,8 +1,5 @@
-use std::String;
-
 use super::nvpair::NvList;
-use super::vdev;
-use super::zfs;
+use super::{vdev, zfs};
 
 pub struct VdevFile {
     path: String,

--- a/filesystem/apps/zfs/xdr/mem_ops.rs
+++ b/filesystem/apps/zfs/xdr/mem_ops.rs
@@ -1,4 +1,4 @@
-use std::*;
+use std::{mem, ptr};
 
 use super::{XdrOps, XdrError, XdrResult};
 

--- a/filesystem/apps/zfs/xdr/xdr.rs
+++ b/filesystem/apps/zfs/xdr/xdr.rs
@@ -1,4 +1,4 @@
-use std::*;
+//use std::*;
 
 #[derive(Debug)]
 pub struct XdrError;

--- a/filesystem/apps/zfs/zap.rs
+++ b/filesystem/apps/zfs/zap.rs
@@ -1,4 +1,4 @@
-use std::*;
+use std::{fmt, mem, ptr, str, Seek};
 
 use super::from_bytes::FromBytes;
 

--- a/filesystem/apps/zfs/zio.rs
+++ b/filesystem/apps/zfs/zio.rs
@@ -1,4 +1,4 @@
-use std::*;
+use std::{mem, ptr, File, Read, Seek, SeekFrom, Write};
 
 use super::block_ptr::BlockPtr;
 use super::dvaddr::DVAddr;


### PR DESCRIPTION
In the shell:
* Described what the `help` argument is used for in the doc comments
* Reduce lines of code by idiomizing in Rust more
* Removed unneeded cloning, because cloning a `&str` is not necessary to use `to_string()`.
