### PR TITLE
Make use of fewer raw pointers, use borrows instead.

### DIFF
--- a/kernel/programs/executor.rs
+++ b/kernel/programs/executor.rs
@@ -12,24 +12,22 @@ use common::memory;
 
 use scheduler;
 use scheduler::context::{CONTEXT_STACK_SIZE, CONTEXT_STACK_ADDR, context_switch,
-                         context_userspace, Context, ContextMemory};
+context_userspace, Context, ContextMemory};
 
 use schemes::Url;
 
 /// Excecute an excecutable
 pub fn execute(url: Url, mut args: Vec<String>) {
     unsafe {
-        let reenable = scheduler::start_no_ints();
 
-        let context_ptr: *mut Context = if let Some(mut current) = Context::current_mut() {
-            current.deref_mut()
-        } else {
-            0 as *mut Context
-        };
 
-        scheduler::end_no_ints(reenable);
 
-        if context_ptr as usize > 0 {
+        if let Some(current) = Context::current_mut() {
+
+            let reenable = scheduler::start_no_ints();
+            let cptr = current.deref_mut();
+            scheduler::end_no_ints(reenable);
+
             Context::spawn("kexec ".to_string() + &url.string, box move || {
                 if let Some(mut resource) = url.open() {
                     let mut vec: Vec<u8> = Vec::new();
@@ -44,21 +42,21 @@ pub fn execute(url: Url, mut args: Vec<String>) {
                         let physical_address = memory::alloc(virtual_size);
 
                         if physical_address > 0 {
-            // Copy progbits
+                            // Copy progbits
                             ::memcpy(physical_address as *mut u8,
                                      (executable.data + segment.off as usize) as *const u8,
                                      segment.file_len as usize);
-            // Zero bss
+                            // Zero bss
                             ::memset((physical_address + segment.file_len as usize) as *mut u8,
-                                     0,
-                                     segment.mem_len as usize - segment.file_len as usize);
+                            0,
+                            segment.mem_len as usize - segment.file_len as usize);
 
-                             memory.push(ContextMemory {
-                                 physical_address: physical_address,
-                                 virtual_address: virtual_address,
-                                 virtual_size: virtual_size,
-                                 writeable: segment.flags & 2 == 2
-                             });
+                            memory.push(ContextMemory {
+                                physical_address: physical_address,
+                                virtual_address: virtual_address,
+                                virtual_size: virtual_size,
+                                writeable: segment.flags & 2 == 2
+                            });
                         }
                     }
 
@@ -79,7 +77,7 @@ pub fn execute(url: Url, mut args: Vec<String>) {
 
                         let reenable = scheduler::start_no_ints();
 
-                        let context = &mut * context_ptr;
+                        let context = cptr;
 
                         context.name = url.to_string();
 

--- a/kernel/scheduler/context.rs
+++ b/kernel/scheduler/context.rs
@@ -77,9 +77,15 @@ pub unsafe fn context_switch(interrupted: bool) {
                     (*current_ptr).unmap();
 
                     if (*next_ptr).kernel_stack > 0 {
-                        (*::tss_ptr).sp0 = (*next_ptr).kernel_stack + CONTEXT_STACK_SIZE - 128;
+                        match ::TSS_PTR {
+                            Some(ref mut x) => x.sp0 = (*next_ptr).kernel_stack + CONTEXT_STACK_SIZE - 128,
+                            None => unreachable!(),
+                        }
                     } else {
-                        (*::tss_ptr).sp0 = 0x200000 - 128;
+                        match ::TSS_PTR {
+                            Some(ref mut x) => x.sp0 = 0x200000 - 128,
+                            None => unreachable!(),
+                        }
                     }
 
                     (*next_ptr).map();

--- a/kernel/syscall/handle.rs
+++ b/kernel/syscall/handle.rs
@@ -53,7 +53,7 @@ pub unsafe fn do_sys_debug(ptr: *const u8, len: usize) {
 
     let reenable = scheduler::start_no_ints();
 
-    if ::env_ptr as usize > 0 {
+    if ::ENV_PTR.is_some() {
         ::env().console.lock().write(bytes);
     } else {
         let serial_status = Pio8::new(0x3F8 + 5);


### PR DESCRIPTION
Note that this do not have performance implication since Option<&T> is optimized to a nullable pointer. As such, this change only affects safety.

It cannot panic (even though it uses `.unwrap()`), because the `None` case is unreachable (and is even optimized away if you look at the LLVM IR output).