### PR TITLE
Fix a typo

### DIFF
--- a/kernel/programs/executor.rs
+++ b/kernel/programs/executor.rs
@@ -16,7 +16,7 @@ context_userspace, Context, ContextMemory};
 
 use schemes::Url;
 
-/// Excecute an excecutable
+/// Execute an executable
 pub fn execute(url: Url, mut args: Vec<String>) {
     unsafe {
 


### PR DESCRIPTION
Excecute -> Execute
excecutable -> executable