### PR TITLE
fix a comment that didn't get detected by markdown

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,7 @@
 #### Other links
 
 - [redox-os.org](http://redox-os.org)
+
 <!-- TODO add more links here -->
 
 <a name="slack" />


### PR DESCRIPTION
I didn't notice this earlier, but there was one comment I added that somehow shows through on view mode. Adding a newline fixed it for some reason.