### PR TITLE
Organize README.md and CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 Thank you for your interest in contributing to Redox! This document is a guide to help newcomers contribute!  
 There are many ways to help us out and we appreciate all of them.
 
-### Index
+## Index
 
 * [Communication](#communication)
  * [Slack Chat](#slack)
@@ -23,7 +23,7 @@ There are many ways to help us out and we appreciate all of them.
 * [Other Ways to Contribute](#other)
  * [Graphic Design](#graphic-design)
 
-### <a name="extern-links" /> Other External Links
+## <a name="extern-links" /> Other External Links
 
 * [redox-os.org](http://redox-os.org)
 * [rust-os-comparison](https://github.com/jackpot51/rust-os-comparison)
@@ -35,11 +35,11 @@ There are many ways to help us out and we appreciate all of them.
 
 ### <a name="slack" /> Slack Chat
 
-The quickest and most open way to communicate with the Redox team is with [Slack](https://slack.com/). Currently, the only way to join our slack team is by sending an email to [info@redox-os.org](mailto:info@redox-os.org), which might take a little while, since it's not automated. We're currently working on an easier way to do this, but this is the most convenient way right now.
+The quickest and most open way to communicate with the Redox team is with [Slack](https://slack.com). Currently, the only way to join our slack team is by sending an email to [info@redox-os.org](mailto:info@redox-os.org), which might take a little while, since it's not automated. We're currently working on an easier way to do this, but this is the most convenient way right now.
 
 ### <a name="reddit" /> Reddit
 
-You can find Redox on Reddit in [/r/rust/](https://www.reddit.com/r/rust/) and [/r/redox/](https://www.reddit.com/r/redox/). The weekly update news is posted on the former.
+You can find Redox on Reddit in [/r/rust/](https://www.reddit.com/r/rust) and [/r/redox/](https://www.reddit.com/r/redox). The weekly update news is posted on the former.
 
 ## <a name="direct-contributing" /> Direct Contributing
 
@@ -57,8 +57,8 @@ You can find Redox on Reddit in [/r/rust/](https://www.reddit.com/r/rust/) and [
 * If you are fluent in Rust, but not OS Development:
 
  * Apps development
- * Shell ((Ion)[https://github.com/redox-os/ion]) development
- * Package manager ((Oxide)[https://github.com/redox-os/oxide]) development
+ * Shell ([Ion](https://github.com/redox-os/ion)) development
+ * Package manager ([Oxide](https://github.com/redox-os/oxide)) development
  * Other high-level code tasks
 
 * If you are fluent in Rust, and have experience with OS Dev:
@@ -73,10 +73,9 @@ A bit more formal way of communication with fellow Redox devs, but a little less
 
 ### <a name="prs" /> Pull Requests
 
-It's completely fine to just submit a small pull request without first making an issue or something, but if it's a big change that will require a lot of planning and reviewing, it's best you start with writing an issue first. Also see (git guidelines)[#git-style-guidelines]
+It's completely fine to just submit a small pull request without first making an issue or something, but if it's a big change that will require a lot of planning and reviewing, it's best you start with writing an issue first. Also see [git guidelines](#git-style-guidelines)
 
-<a name="creating-a-pr" />
-### Creating a Pull Request
+### <a name="creating-a-pr" /> Creating a Pull Request
 
 1. Fork the repository
 2. Clone the original repository to your local PC using one of the following commands based on the protocol you are using:
@@ -94,7 +93,7 @@ It's completely fine to just submit a small pull request without first making an
 5. Optionally create a separate branch (recommended if you're making multiple changes simultaneously) (`git checkout -b my-branch`)
 6. Make changes
 7. Commit (`git add . --all; git commit -m "my commit"`)
-8. Optionally run (rustfmt)[https://github.com/rust-lang-nursery/rustfmt] on the files you changed and commit again if it did anything (check with `git diff` first)
+8. Optionally run [`rustfmt`](https://github.com/rust-lang-nursery/rustfmt) on the files you changed and commit again if it did anything (check with `git diff` first)
 9. Test your changes with `make qemu` or `make virtualbox` (you might have to use `make qemu_no_kvm`) (see [Best Practices and Guidelines])
 10. Pull from upstream (`git fetch upstream; git rebase upstream/master`) (Note: try not to use `git pull`, it is equivalent to doing `git fetch upstream; git merge master upstream/master`, which is not usually preferred for local/fork repositories, although it is fine in some cases.)
 11. Repeat step 9 to make sure the rebase still builds and starts
@@ -112,7 +111,7 @@ It's completely fine to just submit a small pull request without first making an
 * Prefer passing references to the data over owned data. (Don't take `String`, take `&str`. Don't take `Vec<T>` take `&[T]`).
 * Use generics, traits, and other abstractions Rust provides.
 * Be sure to mark parts that need work with `TODO`, `FIXME`, `BUG`, and `UNOPTIMIZED`.
-* Check (Slack)[#slack], (the Website)[#], and **the Subreddit** frequently.
+* Check [Slack](#slack), [the Website](http://redox-os.org), and [the Subreddit](https://www.reddit.com/r/redox) frequently.
 
 ### <a name="kernel" /> Kernel
 
@@ -139,10 +138,11 @@ Since Rust is a relatively small and new language compared to others like C, the
 
 ### <a name="git-style-guidelines" /> Git
 
-* Commit messages should describe their changes in present-tense, e.g. "`Add stuff to file.ext`" instead of "`added stuff to file.ext`". This logically makes more sense because, say you're scrolling through history, and you see a commit named "`create file X`". You immediately know that this is what this commit will do to your working directory. It also generally is just more consistent and conventional.
-* Try to remove duplicate commits from PRs as these clutter up history.
-* Generally, when syncing your local copy with the master branch, you will want to rebase instead of merge. This is because it will create duplicate commits that don't actually do anything when merged into the master branch.
-* When you start to make changes, you will want to create a separate branch, and keep the `master` branch of your fork identical to the main repository, so that you can compare your changes with the main branch and test out a more stable build if you need to. 
+* Commit messages should describe their changes in present-tense, e.g. "`Add stuff to file.ext`" instead of "`added stuff to file.ext`". This makes more sense because of the way Git works, and it's also generally just more consistent and conventional.
+* Try to remove useless duplicate/merge commits from PRs as these clutter up history, and may make it hard to read.
+* Usually, when syncing your local copy with the master branch, you will want to rebase instead of merge. This is because it will create duplicate commits that don't actually do anything when merged into the master branch.
+* When you start to make changes, you will want to create a separate branch, and keep the `master` branch of your fork identical to the main repository, so that you can compare your changes with the main branch and test out a more stable build if you need to.
+* You should have a fork of the repository on GitHub and a local copy on your computer. The local copy should have two remotes; `upstream` and `origin`, `upstream` should be set to the main repository and `origin` should be your fork. 
 
 ## <a name="other" /> Other Ways to Contribute
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Sometimes things go wrong when compiling. Try the following before opening an is
 1. Run `make clean`.
 2. Run `git clean -X -f -d`.
 3. Make sure you have **the latest version of Rust nightly!** ([multirust](https://github.com/brson/multirust) is recommended for managing Rust versions).
-4. Update **GNU Make**, **nasm** and **QEMU/VirtualBox**.
+4. Update **GNU Make**, **NASM** and **QEMU/VirtualBox**.
 5. Pull the upstream master branch (`git remote add upstream git@github.com:redox-os/redox.git; git pull upstream master`).
 
 and then rebuild!
@@ -71,9 +71,9 @@ To manually clone, build and run Redox using a Linux host, run the following com
 $ cd path/to/your/projects/folder/
 
 # HTTPS
-$ git clone --recursive https://github.com/redox-os/redox.git
+$ git clone https://github.com/redox-os/redox.git --origin upstream --recursive
 # SSH
-$ git clone --recursive git@github.com:redox-os/redox.git
+$ git clone git@github.com:redox-os/redox.git --origin upstream --recursive
 
 $ cd redox/
 

--- a/README.md
+++ b/README.md
@@ -48,11 +48,20 @@ If you're interested in this project, and you'd like to help us out, [here](CONT
 
 ```bash
 $ cd path/to/your/projects/folder/
-$ curl -sf https://raw.githubusercontent.com/redox-os/redox/master/bootstrap.sh | sh # Run bootstrap setup
-$ make all # Build Redox
-$ make virtualbox # Launch using VirtualBox
-$ make qemu # Launch using QEMU
-$ make qemu_no_kvm # Launch using QEMU without KVM (Kernel Virtual Machine?). Try if QEMU gives an error.
+
+# Run bootstrap setup
+$ curl -sf https://raw.githubusercontent.com/redox-os/redox/master/bootstrap.sh | sh 
+
+# Build Redox
+$ make all
+
+# Launch using VirtualBox
+$ make virtualbox
+
+# Launch using QEMU
+$ make qemu
+# Launch using QEMU without using KVM (Kernel Virtual Machine). Try if QEMU gives an error.
+$ make qemu_no_kvm
 ```
 
 ### <a name="manual-setup" /> Manual Setup
@@ -60,14 +69,31 @@ $ make qemu_no_kvm # Launch using QEMU without KVM (Kernel Virtual Machine?). Tr
 To manually clone, build and run Redox using a Linux host, run the following commands (with exceptions, be sure to read the comments):
 ```bash
 $ cd path/to/your/projects/folder/
-$ git clone --recursive https://github.com/redox-os/redox.git # HTTPS
-$ git clone --recursive git@github.com:redox-os/redox.git # SSH
+
+# HTTPS
+$ git clone --recursive https://github.com/redox-os/redox.git
+# SSH
+$ git clone --recursive git@github.com:redox-os/redox.git
+
 $ cd redox/
-$ sudo <your package manager> install llvm make nasm virtualbox virtualbox-dkms qemu qemu-kvm # Install/update dependencies
-$ curl -sf https://raw.githubusercontent.com/brson/multirust/master/blastoff.sh | sh # Install multirust
-$ multirust override nightly # Set override toolchain to nightly build
-$ make all # Build Redox
-$ make virtualbox # Launch using VirtualBox
-$ make qemu # Launch using QEMU
-$ make qemu_no_kvm # Launch using QEMU without KVM (Kernel Virtual Machine?). Try if QEMU gives an error.
+
+# Install/update dependencies
+$ sudo <your package manager> install llvm make nasm virtualbox virtualbox-dkms qemu qemu-kvm
+
+# Install multirust
+$ curl -sf https://raw.githubusercontent.com/brson/multirust/master/blastoff.sh | sh
+
+# Set override toolchain to nightly build
+$ multirust override nightly
+
+# Build Redox
+$ make all
+
+# Launch using VirtualBox
+$ make virtualbox
+
+# Launch using QEMU
+$ make qemu
+# Launch using QEMU without using KVM (Kernel Virtual Machine). Try if QEMU gives an error.
+$ make qemu_no_kvm
 ```

--- a/README.md
+++ b/README.md
@@ -14,16 +14,7 @@ Please make sure you use the **latest nightly** of `rustc` before building (for 
 * [What it looks like](#what-it-looks-like)
 * [Help! Redox won't compile](#compile-help)
 * [Contributing to Redox](#contributing)
-* [Cloning the repository](#cloning)
-* [Installation](#installation)
-  * [Building and running](#building-running)
-    * [Debian and Ubuntu family](#debian-ubuntu)
-    * [Archlinux](#arch-linux)
-    * [Fedora](#fedora)
-    * [Suse](#suse)
-    * [NixOS](#nixos)
-    * [OS X](#osx)
-    * [Windows](#windows)
+* [Cloning, Building and running](#cloning-building-running)
 
 
 ## <a name="what-it-looks-like" /> What it looks like
@@ -53,9 +44,22 @@ If you're interested in this project, and you'd like to help us out, [here](CONT
 
 ## <a name="cloning-building-running" /> Cloning, Building, and Running
 
+### <a name="quick-setup" /> Quick Setup
+
+```bash
+$ cd path/to/your/projects/folder/
+$ curl -sf https://raw.githubusercontent.com/redox-os/redox/master/bootstrap.sh | sh # Run bootstrap setup
+$ make all # Build Redox
+$ make virtualbox # Launch using VirtualBox
+$ make qemu # Launch using QEMU
+$ make qemu_no_kvm # Launch using QEMU without KVM (Kernel Virtual Machine?). Try if QEMU gives an error.
+```
+
+### <a name="manual-setup" /> Manual Setup
+
 To manually clone, build and run Redox using a Linux host, run the following commands (with exceptions, be sure to read the comments):
 ```bash
-$ cd my-projects-folder/
+$ cd path/to/your/projects/folder/
 $ git clone --recursive https://github.com/redox-os/redox.git # HTTPS
 $ git clone --recursive git@github.com:redox-os/redox.git # SSH
 $ cd redox/

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ If you're interested in this project, and you'd like to help us out, [here](CONT
 $ cd path/to/your/projects/folder/
 
 # Run bootstrap setup
-$ curl -sf https://raw.githubusercontent.com/redox-os/redox/master/bootstrap.sh -o bootstrap.sh && bash -e bootstrap.sh && rm -rf bootstrap.sh
+$ curl -sf https://raw.githubusercontent.com/redox-os/redox/master/bootstrap.sh -o bootstrap.sh && bash -e bootstrap.sh
 
 # Build Redox
 $ make all

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ If you're interested in this project, and you'd like to help us out, [here](CONT
 $ cd path/to/your/projects/folder/
 
 # Run bootstrap setup
-$ curl -sf https://raw.githubusercontent.com/redox-os/redox/master/bootstrap.sh | sh 
+$ curl -sf https://raw.githubusercontent.com/redox-os/redox/master/bootstrap.sh -o bootstrap.sh && bash -e bootstrap.sh && rm -rf bootstrap.sh
 
 # Build Redox
 $ make all

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Sometimes things go wrong when compiling. Try the following before opening an is
 1. Run `make clean`.
 2. Run `git clean -X -f -d`.
 3. Make sure you have **the latest version of Rust nightly!** ([multirust](https://github.com/brson/multirust) is recommended for managing Rust versions).
-4. Update **LLVM**, **GNU Make**, **nasm** and **QEMU/VirtualBox**.
+4. Update **GNU Make**, **nasm** and **QEMU/VirtualBox**.
 5. Pull the upstream master branch (`git remote add upstream git@github.com:redox-os/redox.git; git pull upstream master`).
 
 and then rebuild!


### PR DESCRIPTION
I removed the inconsistent and unorganized multiplatform build instructions in favor of two instruction sets, quick setup and manual setup. Quick setup uses `bootstrap.sh`, and manual setup just lists all the commands you need to do it manually. This should make it alot more simple and easy for beginners, as well as more advanced users.

The diff is a bit hard to read, you can just look at the final changed files here https://github.com/polymetric1/redox/blob/contributing-md/README.md
https://github.com/polymetric1/redox/blob/contributing-md/CONTRIBUTING.md