### PR TITLE
[WIP] Some fixes to ATA DMA driver

### DIFF
--- a/kernel/disk/ide.rs
+++ b/kernel/disk/ide.rs
@@ -394,8 +394,8 @@ impl Disk {
         }
 
         let mut sectors = (destination.read(100) as u64) | ((destination.read(101) as u64) << 16) |
-                      ((destination.read(102) as u64) << 32) |
-                      ((destination.read(103) as u64) << 48);
+                          ((destination.read(102) as u64) << 32) |
+                          ((destination.read(103) as u64) << 48);
 
         if sectors == 0 {
             sectors = (destination.read(60) as u64) | ((destination.read(61) as u64) << 16);
@@ -552,7 +552,11 @@ impl Disk {
                                            eot: eot,
                                        });
 
-                        self.dma_requests.lock().push_back(DMARequest { lba: req.extent.block + (i as u64) * 128, sectors: 128, read: req.read });
+                        self.dma_requests.lock().push_back(DMARequest {
+                            lba: req.extent.block + (i as u64) * 128,
+                            sectors: 128,
+                            read: req.read,
+                        });
 
                         size -= 65536;
                         i += 1;
@@ -565,7 +569,11 @@ impl Disk {
                                            eot: PRD_EOT,
                                        });
 
-                       self.dma_requests.lock().push_back(DMARequest { lba: req.extent.block + (i as u64) * 128, sectors: (size / 512) as u16, read: req.read });
+                        self.dma_requests.lock().push_back(DMARequest {
+                            lba: req.extent.block + (i as u64) * 128,
+                            sectors: (size / 512) as u16,
+                            read: req.read,
+                        });
                         size = 0;
                         i += 1;
                     }
@@ -611,7 +619,7 @@ impl Disk {
         }
 
         if let Some(ref req) = *self.dma_request.lock() {
-             while self.ide_read(ATA_REG_STATUS) & ATA_SR_BSY == ATA_SR_BSY {
+            while self.ide_read(ATA_REG_STATUS) & ATA_SR_BSY == ATA_SR_BSY {
 
             }
 

--- a/kernel/disk/ide.rs
+++ b/kernel/disk/ide.rs
@@ -60,13 +60,14 @@ const STS_ERR: u8 = 2;
 const STS_ACT: u8 = 1;
 
 /// PRDT End of Table
-const PRD_EOT: u32 = 0x80000000;
+const PRD_EOT: u16 = 0x8000;
 
 /// Physical Region Descriptor
 #[repr(packed)]
 struct Prd {
     addr: u32,
-    size: u32,
+    size: u16,
+    eot: u16,
 }
 
 struct Prdt {
@@ -168,6 +169,12 @@ const ATA_REG_CONTROL: u16 = 0x0C;
 const ATA_REG_ALTSTATUS: u16 = 0x0C;
 const ATA_REG_DEVADDRESS: u16 = 0x0D;
 
+struct DMARequest {
+    lba: u64,
+    sectors: u16,
+    read: bool,
+}
+
 /// A disk (data storage)
 pub struct Disk {
     base: u16,
@@ -175,6 +182,8 @@ pub struct Disk {
     master: bool,
     request: Intex<Option<Request>>,
     requests: Intex<VecDeque<Request>>,
+    dma_request: Intex<Option<DMARequest>>,
+    dma_requests: Intex<VecDeque<DMARequest>>,
     cmd: Pio8,
     sts: Pio8,
     prdt: Option<Prdt>,
@@ -190,6 +199,8 @@ impl Disk {
             master: true,
             request: Intex::new(None),
             requests: Intex::new(VecDeque::new()),
+            dma_request: Intex::new(None),
+            dma_requests: Intex::new(VecDeque::new()),
             cmd: Pio8::new(base),
             sts: Pio8::new(base + 2),
             prdt: Prdt::new(base + 4),
@@ -205,6 +216,8 @@ impl Disk {
             master: false,
             request: Intex::new(None),
             requests: Intex::new(VecDeque::new()),
+            dma_request: Intex::new(None),
+            dma_requests: Intex::new(VecDeque::new()),
             cmd: Pio8::new(base),
             sts: Pio8::new(base + 2),
             prdt: Prdt::new(base + 4),
@@ -220,6 +233,8 @@ impl Disk {
             master: true,
             request: Intex::new(None),
             requests: Intex::new(VecDeque::new()),
+            dma_request: Intex::new(None),
+            dma_requests: Intex::new(VecDeque::new()),
             cmd: Pio8::new(base + 8),
             sts: Pio8::new(base + 0xA),
             prdt: Prdt::new(base + 0xC),
@@ -235,6 +250,8 @@ impl Disk {
             master: false,
             request: Intex::new(None),
             requests: Intex::new(VecDeque::new()),
+            dma_request: Intex::new(None),
+            dma_requests: Intex::new(VecDeque::new()),
             cmd: Pio8::new(base + 8),
             sts: Pio8::new(base + 0xA),
             prdt: Prdt::new(base + 0xC),
@@ -398,9 +415,9 @@ impl Disk {
             }
 
             if self.master {
-                self.ide_write(ATA_REG_HDDEVSEL, 0xE0);
+                self.ide_write(ATA_REG_HDDEVSEL, 0x40);
             } else {
-                self.ide_write(ATA_REG_HDDEVSEL, 0xF0);
+                self.ide_write(ATA_REG_HDDEVSEL, 0x50);
             }
 
             self.ide_write(ATA_REG_SECCOUNT1, ((count >> 8) & 0xFF) as u8);
@@ -439,9 +456,9 @@ impl Disk {
             }
 
             if self.master {
-                self.ide_write(ATA_REG_HDDEVSEL, 0xE0);
+                self.ide_write(ATA_REG_HDDEVSEL, 0x40);
             } else {
-                self.ide_write(ATA_REG_HDDEVSEL, 0xF0);
+                self.ide_write(ATA_REG_HDDEVSEL, 0x50);
             }
 
             self.ide_write(ATA_REG_SECCOUNT1, ((count >> 8) & 0xFF) as u8);
@@ -491,30 +508,32 @@ impl Disk {
 
             let cmd = self.cmd.read();
             if cmd & CMD_ACT == CMD_ACT {
-                self.next_request();
+                self.next_dma_request();
             }
         }
     }
 
     unsafe fn next_request(&mut self) {
-        let mut requests = self.requests.lock();
-        let mut request = self.request.lock();
+        {
+            let mut requests = self.requests.lock();
+            let mut request = self.request.lock();
 
-        self.cmd.write(CMD_DIR);
-        if let Some(ref mut prdt) = self.prdt {
-            prdt.reg.write(0 as u32);
+            self.cmd.write(CMD_DIR);
+            if let Some(ref mut prdt) = self.prdt {
+                prdt.reg.write(0 as u32);
+            }
+
+            if let Some(ref mut req) = *request {
+                req.complete.store(true, Ordering::SeqCst);
+            }
+
+            *request = requests.pop_front();
         }
 
-        if let Some(ref mut req) = *request {
-            req.complete.store(true, Ordering::SeqCst);
-        }
-
-        *request = requests.pop_front();
-
-        if let Some(ref req) = *request {
+        let mut prdt_set = false;
+        if let Some(ref req) = *self.request.lock() {
             if req.mem > 0 {
                 let sectors = (req.extent.length + 511) / 512;
-                let mut prdt_set = false;
                 if let Some(ref mut prdt) = self.prdt {
                     let mut size = sectors * 512;
                     let mut i = 0;
@@ -529,8 +548,11 @@ impl Disk {
                         prdt.mem.store(i,
                                        Prd {
                                            addr: (req.mem + i * 65536) as u32,
-                                           size: eot,
+                                           size: 0,
+                                           eot: eot,
                                        });
+
+                        self.dma_requests.lock().push_back(DMARequest { lba: req.extent.block + (i as u64) * 128, sectors: 128, read: req.read });
 
                         size -= 65536;
                         i += 1;
@@ -539,9 +561,11 @@ impl Disk {
                         prdt.mem.store(i,
                                        Prd {
                                            addr: (req.mem + i * 65536) as u32,
-                                           size: size as u32 | PRD_EOT,
+                                           size: size as u16,
+                                           eot: PRD_EOT,
                                        });
 
+                       self.dma_requests.lock().push_back(DMARequest { lba: req.extent.block + (i as u64) * 128, sectors: (size / 512) as u16, read: req.read });
                         size = 0;
                         i += 1;
                     }
@@ -562,50 +586,8 @@ impl Disk {
 
                 if prdt_set {
                     if req.read {
-                        while self.ide_read(ATA_REG_STATUS) & ATA_SR_BSY == ATA_SR_BSY {
-
-                        }
-
-                        if self.master {
-                            self.ide_write(ATA_REG_HDDEVSEL, 0xE0);
-                        } else {
-                            self.ide_write(ATA_REG_HDDEVSEL, 0xF0);
-                        }
-
-                        self.ide_write(ATA_REG_SECCOUNT1, ((sectors >> 8) & 0xFF) as u8);
-                        self.ide_write(ATA_REG_LBA3, ((req.extent.block >> 24) & 0xFF) as u8);
-                        self.ide_write(ATA_REG_LBA4, ((req.extent.block >> 32) & 0xFF) as u8);
-                        self.ide_write(ATA_REG_LBA5, ((req.extent.block >> 40) & 0xFF) as u8);
-
-                        self.ide_write(ATA_REG_SECCOUNT0, (sectors & 0xFF) as u8);
-                        self.ide_write(ATA_REG_LBA0, (req.extent.block & 0xFF) as u8);
-                        self.ide_write(ATA_REG_LBA1, ((req.extent.block >> 8) & 0xFF) as u8);
-                        self.ide_write(ATA_REG_LBA2, ((req.extent.block >> 16) & 0xFF) as u8);
-                        self.ide_write(ATA_REG_COMMAND, ATA_CMD_READ_DMA_EXT);
-
                         self.cmd.write(CMD_ACT | CMD_DIR);
                     } else {
-                        while self.ide_read(ATA_REG_STATUS) & ATA_SR_BSY == ATA_SR_BSY {
-
-                        }
-
-                        if self.master {
-                            self.ide_write(ATA_REG_HDDEVSEL, 0xE0);
-                        } else {
-                            self.ide_write(ATA_REG_HDDEVSEL, 0xF0);
-                        }
-
-                        self.ide_write(ATA_REG_SECCOUNT1, ((sectors >> 8) & 0xFF) as u8);
-                        self.ide_write(ATA_REG_LBA3, ((req.extent.block >> 24) & 0xFF) as u8);
-                        self.ide_write(ATA_REG_LBA4, ((req.extent.block >> 32) & 0xFF) as u8);
-                        self.ide_write(ATA_REG_LBA5, ((req.extent.block >> 40) & 0xFF) as u8);
-
-                        self.ide_write(ATA_REG_SECCOUNT0, (sectors & 0xFF) as u8);
-                        self.ide_write(ATA_REG_LBA0, (req.extent.block & 0xFF) as u8);
-                        self.ide_write(ATA_REG_LBA1, ((req.extent.block >> 8) & 0xFF) as u8);
-                        self.ide_write(ATA_REG_LBA2, ((req.extent.block >> 16) & 0xFF) as u8);
-                        self.ide_write(ATA_REG_COMMAND, ATA_CMD_WRITE_DMA_EXT);
-
                         self.cmd.write(CMD_ACT);
                     }
                 }
@@ -613,5 +595,52 @@ impl Disk {
                 debug!("IDE Request mem is 0\n");
             }
         }
+
+        if prdt_set {
+            // Start the first DMA request
+            self.next_dma_request();
+        }
+    }
+
+    unsafe fn next_dma_request(&mut self) {
+        {
+            let mut dma_requests = self.dma_requests.lock();
+            let mut dma_request = self.dma_request.lock();
+
+            *dma_request = dma_requests.pop_front();
+        }
+
+        if let Some(ref req) = *self.dma_request.lock() {
+             while self.ide_read(ATA_REG_STATUS) & ATA_SR_BSY == ATA_SR_BSY {
+
+            }
+
+            if self.master {
+                self.ide_write(ATA_REG_HDDEVSEL, 0x40);
+            } else {
+                self.ide_write(ATA_REG_HDDEVSEL, 0x50);
+            }
+
+            self.ide_write(ATA_REG_SECCOUNT1, ((req.sectors >> 8) & 0xFF) as u8);
+            self.ide_write(ATA_REG_LBA3, ((req.lba >> 24) & 0xFF) as u8);
+            self.ide_write(ATA_REG_LBA4, ((req.lba >> 32) & 0xFF) as u8);
+            self.ide_write(ATA_REG_LBA5, ((req.lba >> 40) & 0xFF) as u8);
+
+            self.ide_write(ATA_REG_SECCOUNT0, (req.sectors & 0xFF) as u8);
+            self.ide_write(ATA_REG_LBA0, (req.lba & 0xFF) as u8);
+            self.ide_write(ATA_REG_LBA1, ((req.lba >> 8) & 0xFF) as u8);
+            self.ide_write(ATA_REG_LBA2, ((req.lba >> 16) & 0xFF) as u8);
+
+            if req.read {
+                self.ide_write(ATA_REG_COMMAND, ATA_CMD_READ_DMA_EXT);
+            } else {
+                self.ide_write(ATA_REG_COMMAND, ATA_CMD_WRITE_DMA_EXT);
+            }
+
+            return;
+        }
+
+        // We are done with this set of requests
+        self.next_request();
     }
 }

--- a/kernel/schemes/file.rs
+++ b/kernel/schemes/file.rs
@@ -610,7 +610,7 @@ impl KScheme for FileScheme {
                             if let Some(data) = Memory::<u8>::new(extent.length as usize) {
                                 let sectors = (extent.length as usize + 511) / 512;
                                 let mut sector: usize = 0;
-                                while sectors - sector >= 65536 {
+                                while sectors - sector >= 128 {
                                     if PIO {
                                         unsafe {
                                             self.fs.disk.read(extent.block + sector as u64,
@@ -621,7 +621,7 @@ impl KScheme for FileScheme {
                                         let request = Request {
                                             extent: Extent {
                                                 block: extent.block + sector as u64,
-                                                length: 65536 * 512,
+                                                length: 65536,
                                             },
                                             mem: unsafe { data.address() } + sector * 512,
                                             read: true,
@@ -635,7 +635,7 @@ impl KScheme for FileScheme {
                                         }
                                     }
 
-                                    sector += 65535;
+                                    sector += 128;
                                 }
                                 if sector < sectors {
                                     if PIO {


### PR DESCRIPTION
**NOTE**: This implementation is broken. I'm mainly opening this to get some feedback if this is worth fixing (I know AHCI things are happening, so not sure if the DMA stuff will continue to live?) and also if anyone can see what bugs there are here. The issue I'm seeing is that the first DMA read request seems to work (the ELF header of the first binary looks correct, but then after that the reads look wrong, although I haven't looked too closely at the exact data read).

This is an attempt to get Redox to boot in VirtualBox using the ATA driver in DMA mode. Some reads that were previously failing are now working, but other ones that previously worked are now failing.

The main change here is that we send an ATA command for each PRD in the PRDT, instead of a single command for the entire section to be read.

There is also a change to separate out the EOT u16 part in the Prd from the size (the size can only be u16 anyways), and using the right bytes for HDDEVSEL (the old bytes were for the 28-bit LBAs instead of the 48-bit LBAs that we use.