### PR TITLE
Fix typo & link to full size screenshots

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,7 +65,7 @@ You can find Redox on Reddit in [/r/rust/](https://www.reddit.com/r/rust) and [/
 
 ### <a name="gh-issues"> GitHub Issues </a>
 
-A bit more formal way of communication with fellow Redox devs, but a little less quick and convienent like the Slack chat (unless of course you aren't in it yet, which if you're going to be involved in this project really at all, it is recommended that you request to join). These are for more specific topics.
+A bit more formal way of communication with fellow Redox devs, but a little less quick and convenient like the Slack chat (unless of course you aren't in it yet, which if you're going to be involved in this project really at all, it is recommended that you request to join). These are for more specific topics.
 
 ### <a name="prs"> Pull Requests </a>
 

--- a/README.md
+++ b/README.md
@@ -21,13 +21,13 @@ Please make sure you use the **latest nightly** of `rustc` before building (for 
 
 ## <a name="what-it-looks-like"> What it looks like </a>
 
-<img alt="Redox" height="150" src="img/screenshots/Desktop.png">
-<img alt="Redox" height="150" src="img/screenshots/Fancy_opacity.png">
-<img alt="Redox" height="150" src="img/screenshots/File_manager.png">
+<img alt="Redox" height="150" src="https://raw.githubusercontent.com/redox-os/redox/master/img/screenshots/Desktop.png">
+<img alt="Redox" height="150" src="https://raw.githubusercontent.com/redox-os/redox/master/img/screenshots/Fancy_opacity.png">
+<img alt="Redox" height="150" src="https://raw.githubusercontent.com/redox-os/redox/master/img/screenshots/File_manager.png">
 
-<img alt="Redox" height="150" src="img/screenshots/Sodium_v1.png">
-<img alt="Redox" height="150" src="img/screenshots/Boot.png">
-<img alt="Redox" height="150" src="img/screenshots/start.png">
+<img alt="Redox" height="150" src="https://raw.githubusercontent.com/redox-os/redox/master/img/screenshots/Sodium_v1.png">
+<img alt="Redox" height="150" src="https://raw.githubusercontent.com/redox-os/redox/master/img/screenshots/Boot.png">
+<img alt="Redox" height="150" src="https://raw.githubusercontent.com/redox-os/redox/master/img/screenshots/start.png">
 
 ## <a name="compile-help"> Help! Redox won't compile! </a>
 
@@ -45,7 +45,7 @@ and then rebuild!
 
 If you're interested in this project, and you'd like to help us out, [here](CONTRIBUTING.md) is a list of ways you can do just that.
 
-## <a name="cloning-building-running"> Cloning, Building, and Running </a€
+## <a name="cloning-building-running"> Cloning, Building, and Running </a>
 
 ### <a name="quick-setup" /> Quick Setup </a>
 


### PR DESCRIPTION
Fixed a minor typo in CONTRIBUTING.md, and changed the screenshots in README.md to open the full images.