### PR TITLE
Rewrite Pio{8,16,32} as generics

### DIFF
--- a/kernel/audio/ac97.rs
+++ b/kernel/audio/ac97.rs
@@ -44,18 +44,18 @@ impl Resource for AC97Resource {
         unsafe {
             let audio = self.audio as u16;
 
-            let mut master_volume = Pio16::new(audio + 2);
-            let mut pcm_volume = Pio16::new(audio + 0x18);
+            let mut master_volume = Pio::<u16>::new(audio + 2);
+            let mut pcm_volume = Pio::<u16>::new(audio + 0x18);
 
             master_volume.write(0x808);
             pcm_volume.write(0x808);
 
             let bus_master = self.bus_master as u16;
 
-            let mut po_bdbar = Pio32::new(bus_master + 0x10);
-            let po_civ = Pio8::new(bus_master + 0x14);
-            let mut po_lvi = Pio8::new(bus_master + 0x15);
-            let mut po_cr = Pio8::new(bus_master + 0x1B);
+            let mut po_bdbar = Pio::<u32>::new(bus_master + 0x10);
+            let po_civ = Pio::<u8>::new(bus_master + 0x14);
+            let mut po_lvi = Pio::<u8>::new(bus_master + 0x15);
+            let mut po_cr = Pio::<u8>::new(bus_master + 0x1B);
 
             loop {
                 if po_cr.read() & 1 == 0 {

--- a/kernel/disk/ide.rs
+++ b/kernel/disk/ide.rs
@@ -53,13 +53,13 @@ struct Prd {
 }
 
 struct Prdt {
-    reg: Pio32,
+    reg: Pio<u32>,
     mem: Memory<Prd>,
 }
 
 impl Prdt {
     fn new(port: u16) -> Self {
-        let mut reg = Pio32::new(port);
+        let mut reg = Pio::<u32>::new(port);
         unsafe { reg.write(0) };
 
         Prdt {
@@ -192,8 +192,8 @@ impl Ide {
 
 /// A disk (data storage)
 pub struct IdeDisk {
-    cmd: Pio8,
-    sts: Pio8,
+    cmd: Pio<u8>,
+    sts: Pio<u8>,
     prdt: Prdt,
     base: u16,
     ctrl: u16,
@@ -204,8 +204,8 @@ pub struct IdeDisk {
 impl IdeDisk {
     pub fn new(busmaster: u16, base: u16, ctrl: u16, irq: u8, master: bool) -> Option<Self> {
         let ret = IdeDisk {
-            cmd: Pio8::new(busmaster),
-            sts: Pio8::new(busmaster + 2),
+            cmd: Pio::<u8>::new(busmaster),
+            sts: Pio::<u8>::new(busmaster + 2),
             prdt: Prdt::new(busmaster + 4),
             base: base,
             ctrl: ctrl,
@@ -309,7 +309,7 @@ impl IdeDisk {
             return false;
         }
 
-        let data = Pio16::new(self.base + ATA_REG_DATA);
+        let data = Pio::<u16>::new(self.base + ATA_REG_DATA);
         let mut destination = Memory::<u16>::new(256).unwrap();
         for word in 0..256 {
             destination.write(word, data.read());

--- a/kernel/disk/ide.rs
+++ b/kernel/disk/ide.rs
@@ -60,7 +60,7 @@ struct Prdt {
 impl Prdt {
     fn new(port: u16) -> Self {
         let mut reg = Pio::<u32>::new(port);
-        unsafe { reg.write(0) };
+        reg.write(0);
 
         Prdt {
             reg: reg,
@@ -71,7 +71,7 @@ impl Prdt {
 
 impl Drop for Prdt {
     fn drop(&mut self) {
-        unsafe { self.reg.write(0) };
+        self.reg.write(0);
     }
 }
 

--- a/kernel/drivers/pci/config.rs
+++ b/kernel/drivers/pci/config.rs
@@ -6,8 +6,8 @@ pub struct PciConfig {
     bus: u8,
     slot: u8,
     func: u8,
-    addr: Pio32,
-    data: Pio32,
+    addr: Pio<u32>,
+    data: Pio<u32>,
 }
 
 impl PciConfig {
@@ -17,8 +17,8 @@ impl PciConfig {
             bus: bus,
             slot: slot,
             func: func,
-            addr: Pio32::new(0xCF8),
-            data: Pio32::new(0xCFC),
+            addr: Pio::<u32>::new(0xCF8),
+            data: Pio::<u32>::new(0xCFC),
         }
     }
 

--- a/kernel/drivers/pio.rs
+++ b/kernel/drivers/pio.rs
@@ -138,12 +138,12 @@ impl Pio8 {
 
 // TODO: Remove
 pub unsafe fn inb(port: u16) -> u8 {
-    return Pio8::new(port).read();
+    Pio::<u8>::new(port).read()
 }
 
 // TODO: Remove
 pub unsafe fn outb(port: u16, value: u8) {
-    Pio8::new(port).write(value);
+    Pio::<u8>::new(port).write(value);
 }
 
 /// PIO16
@@ -187,12 +187,12 @@ impl Pio16 {
 
 // TODO: Remove
 pub unsafe fn inw(port: u16) -> u16 {
-    return Pio16::new(port).read();
+    Pio::<u16>::new(port).read()
 }
 
 // TODO: Remove
 pub unsafe fn outw(port: u16, value: u16) {
-    Pio16::new(port).write(value);
+    Pio::<u16>::new(port).write(value);
 }
 
 /// PIO32
@@ -236,10 +236,10 @@ impl Pio32 {
 
 // TODO: Remove
 pub unsafe fn ind(port: u16) -> u32 {
-    return Pio32::new(port).read();
+    Pio::<u32>::new(port).read()
 }
 
 // TODO: Remove
 pub unsafe fn outd(port: u16, value: u32) {
-    Pio32::new(port).write(value);
+    Pio::<u32>::new(port).write(value);
 }

--- a/kernel/drivers/pio.rs
+++ b/kernel/drivers/pio.rs
@@ -23,7 +23,7 @@ impl ReadWrite<u8> for Pio<u8> {
         unsafe {
             asm!("in $0, $1" : "={al}"(value) : "{dx}"(self.port) : "memory" : "intel", "volatile");
         }
-        return value;
+        value
     }
 
     /// Write
@@ -42,7 +42,7 @@ impl ReadWrite<u16> for Pio<u16> {
         unsafe {
             asm!("in $0, $1" : "={ax}"(value) : "{dx}"(self.port) : "memory" : "intel", "volatile");
         }
-        return value;
+        value
     }
 
     /// Write
@@ -61,7 +61,7 @@ impl ReadWrite<u32> for Pio<u32> {
         unsafe {
             asm!("in $0, $1" : "={eax}"(value) : "{dx}"(self.port) : "memory" : "intel", "volatile");
         }
-        return value;
+        value
     }
 
     /// Write
@@ -78,10 +78,10 @@ impl<T> Pio<T>
 {
     /// Create a PIO from a given port
     pub fn new(port: u16) -> Self {
-        return Pio::<T> {
+        Pio::<T> {
             port: port,
             value: PhantomData,
-        };
+        }
     }
 
     pub fn readf(&self, flags: T) -> bool {

--- a/kernel/drivers/pio.rs
+++ b/kernel/drivers/pio.rs
@@ -97,45 +97,6 @@ impl<T> Pio<T>
     }
 }
 
-/// PIO8
-#[derive(Copy, Clone)]
-pub struct Pio8 {
-    port: u16,
-}
-
-impl Pio8 {
-    /// Create a PIO8 from a given port
-    pub fn new(port: u16) -> Self {
-        return Pio8 { port: port };
-    }
-
-    /// Read
-    pub unsafe fn read(&self) -> u8 {
-        let value: u8;
-        asm!("in $0, $1" : "={al}"(value) : "{dx}"(self.port) : "memory" : "intel", "volatile");
-        return value;
-    }
-
-    /// Write
-    pub unsafe fn write(&mut self, value: u8) {
-        asm!("out $1, $0" : : "{al}"(value), "{dx}"(self.port) : "memory" : "intel", "volatile");
-    }
-
-    pub unsafe fn readf(&self, flags: u8) -> bool {
-        self.read() & flags == flags
-    }
-
-    pub unsafe fn writef(&mut self, flags: u8, value: bool) {
-        if value {
-            let value = self.read() | flags;
-            self.write(value);
-        } else {
-            let value = self.read() & !flags;
-            self.write(value);
-        }
-    }
-}
-
 // TODO: Remove
 pub unsafe fn inb(port: u16) -> u8 {
     Pio::<u8>::new(port).read()
@@ -146,45 +107,6 @@ pub unsafe fn outb(port: u16, value: u8) {
     Pio::<u8>::new(port).write(value);
 }
 
-/// PIO16
-#[derive(Copy, Clone)]
-pub struct Pio16 {
-    port: u16,
-}
-
-impl Pio16 {
-    /// Create a new PIO16 from a given port
-    pub fn new(port: u16) -> Self {
-        return Pio16 { port: port };
-    }
-
-    /// Read
-    pub unsafe fn read(&self) -> u16 {
-        let value: u16;
-        asm!("in $0, $1" : "={ax}"(value) : "{dx}"(self.port) : "memory" : "intel", "volatile");
-        return value;
-    }
-
-    /// Write
-    pub unsafe fn write(&mut self, value: u16) {
-        asm!("out $1, $0" : : "{ax}"(value), "{dx}"(self.port) : "memory" : "intel", "volatile");
-    }
-
-    pub unsafe fn readf(&self, flags: u16) -> bool {
-        self.read() & flags == flags
-    }
-
-    pub unsafe fn writef(&mut self, flags: u16, value: bool) {
-        if value {
-            let value = self.read() | flags;
-            self.write(value);
-        } else {
-            let value = self.read() & !flags;
-            self.write(value);
-        }
-    }
-}
-
 // TODO: Remove
 pub unsafe fn inw(port: u16) -> u16 {
     Pio::<u16>::new(port).read()
@@ -193,45 +115,6 @@ pub unsafe fn inw(port: u16) -> u16 {
 // TODO: Remove
 pub unsafe fn outw(port: u16, value: u16) {
     Pio::<u16>::new(port).write(value);
-}
-
-/// PIO32
-#[derive(Copy, Clone)]
-pub struct Pio32 {
-    port: u16,
-}
-
-impl Pio32 {
-    /// Create a new PIO32 from a port
-    pub fn new(port: u16) -> Self {
-        return Pio32 { port: port };
-    }
-
-    /// Read
-    pub unsafe fn read(&self) -> u32 {
-        let value: u32;
-        asm!("in $0, $1" : "={eax}"(value) : "{dx}"(self.port) : "memory" : "intel", "volatile");
-        return value;
-    }
-
-    /// Write
-    pub unsafe fn write(&mut self, value: u32) {
-        asm!("out $1, $0" : : "{eax}"(value), "{dx}"(self.port) : "memory" : "intel", "volatile");
-    }
-
-    pub unsafe fn readf(&self, flags: u32) -> bool {
-        self.read() & flags == flags
-    }
-
-    pub unsafe fn writef(&mut self, flags: u32, value: bool) {
-        if value {
-            let value = self.read() | flags;
-            self.write(value);
-        } else {
-            let value = self.read() & !flags;
-            self.write(value);
-        }
-    }
 }
 
 // TODO: Remove

--- a/kernel/drivers/pio.rs
+++ b/kernel/drivers/pio.rs
@@ -1,4 +1,101 @@
-use core::{u8, u16, u32};
+use core::cmp::PartialEq;
+use core::ops::{BitAnd, BitOr, Not};
+use core::marker::PhantomData;
+
+pub trait ReadWrite<T>
+{
+    fn read(&self) -> T;
+    fn write(&self, value: T);
+}
+
+/// Generic PIO
+#[derive(Copy, Clone)]
+pub struct Pio<T> {
+    port: u16,
+    value: PhantomData<T>,
+}
+
+/// Read/Write for byte PIO
+impl ReadWrite<u8> for Pio<u8> {
+    /// Read
+    fn read(&self) -> u8 {
+        let value: u8;
+        unsafe {
+            asm!("in $0, $1" : "={al}"(value) : "{dx}"(self.port) : "memory" : "intel", "volatile");
+        }
+        return value;
+    }
+
+    /// Write
+    fn write(&self, value: u8) {
+        unsafe {
+            asm!("out $1, $0" : : "{al}"(value), "{dx}"(self.port) : "memory" : "intel", "volatile");
+        }
+    }
+}
+
+/// Read/Write for word PIO
+impl ReadWrite<u16> for Pio<u16> {
+    /// Read
+    fn read(&self) -> u16 {
+        let value: u16;
+        unsafe {
+            asm!("in $0, $1" : "={ax}"(value) : "{dx}"(self.port) : "memory" : "intel", "volatile");
+        }
+        return value;
+    }
+
+    /// Write
+    fn write(&self, value: u16) {
+        unsafe {
+            asm!("out $1, $0" : : "{ax}"(value), "{dx}"(self.port) : "memory" : "intel", "volatile");
+        }
+    }
+}
+
+/// Read/Write for doubleword PIO
+impl ReadWrite<u32> for Pio<u32> {
+    /// Read
+    fn read(&self) -> u32 {
+        let value: u32;
+        unsafe {
+            asm!("in $0, $1" : "={eax}"(value) : "{dx}"(self.port) : "memory" : "intel", "volatile");
+        }
+        return value;
+    }
+
+    /// Write
+    fn write(&self, value: u32) {
+        unsafe {
+            asm!("out $1, $0" : : "{eax}"(value), "{dx}"(self.port) : "memory" : "intel", "volatile");
+        }
+    }
+}
+
+impl<T> Pio<T>
+    where Pio<T>: ReadWrite<T>,
+          T: BitAnd<Output = T> + BitOr<Output = T> + PartialEq<T> + Not<Output = T> + Copy
+{
+    /// Create a PIO from a given port
+    pub fn new(port: u16) -> Self {
+        return Pio::<T> {
+            port: port,
+            value: PhantomData,
+        };
+    }
+
+    pub fn readf(&self, flags: T) -> bool {
+        (self.read() & flags) as T == flags
+    }
+
+    pub fn writef(&mut self, flags: T, value: bool) {
+        let tmp: T = match value {
+            true => self.read() | flags,
+            false => self.read() & !flags,
+        };
+        self.write(tmp);
+    }
+}
 
 /// PIO8
 #[derive(Copy, Clone)]
@@ -33,7 +130,7 @@ impl Pio8 {
             let value = self.read() | flags;
             self.write(value);
         } else {
-            let value = self.read() & (u8::MAX - flags);
+            let value = self.read() & !flags;
             self.write(value);
         }
     }
@@ -82,7 +179,7 @@ impl Pio16 {
             let value = self.read() | flags;
             self.write(value);
         } else {
-            let value = self.read() & (u16::MAX - flags);
+            let value = self.read() & !flags;
             self.write(value);
         }
     }
@@ -131,7 +228,7 @@ impl Pio32 {
             let value = self.read() | flags;
             self.write(value);
         } else {
-            let value = self.read() & (u32::MAX - flags);
+            let value = self.read() & !flags;
             self.write(value);
         }
     }

--- a/kernel/drivers/ps2.rs
+++ b/kernel/drivers/ps2.rs
@@ -15,9 +15,9 @@ use drivers::kb_layouts::layouts;
 /// PS2
 pub struct Ps2 {
     /// The data
-    data: Pio8,
+    data: Pio<u8>,
     /// The command
-    cmd: Pio8,
+    cmd: Pio<u8>,
     /// Left shift?
     lshift: bool,
     /// Right shift?
@@ -45,8 +45,8 @@ impl Ps2 {
     /// Create new PS2 data
     pub fn new() -> Box<Self> {
         let mut module = box Ps2 {
-            data: Pio8::new(0x60),
-            cmd: Pio8::new(0x64),
+            data: Pio::<u8>::new(0x60),
+            cmd: Pio::<u8>::new(0x64),
             lshift: false,
             rshift: false,
             caps_lock: false,

--- a/kernel/drivers/ps2.rs
+++ b/kernel/drivers/ps2.rs
@@ -120,7 +120,7 @@ impl Ps2 {
 
     /// Keyboard interrupt
     pub fn keyboard_interrupt(&mut self) -> Option<KeyEvent> {
-        let mut scancode = unsafe { self.data.read() };
+        let mut scancode = self.data.read();
 
         if scancode == 0 {
             return None;
@@ -144,7 +144,7 @@ impl Ps2 {
                 self.caps_lock = false;
             }
         } else if scancode == 0xE0 {
-            let scancode_byte_2 = unsafe { self.data.read() };
+            let scancode_byte_2 = self.data.read();
             if scancode_byte_2 == 0x38 {
                 self.altgr = true;
             } else if scancode_byte_2 == 0xB8 {
@@ -197,7 +197,7 @@ impl Ps2 {
 
     /// Mouse interrupt
     pub fn mouse_interrupt(&mut self) -> Option<MouseEvent> {
-        let byte = unsafe { self.data.read() };
+        let byte = self.data.read();
         if self.mouse_i == 0 {
             if byte & 0x8 == 0x8 {
                 self.mouse_packet[0] = byte;
@@ -272,7 +272,7 @@ impl KScheme for Ps2 {
 
     fn on_poll(&mut self) {
         loop {
-            let status = unsafe { self.cmd.read() };
+            let status = self.cmd.read();
             if status & 0x21 == 1 {
                 if let Some(key_event) = self.keyboard_interrupt() {
                     ::env().events.lock().push_back(key_event.to_event());

--- a/kernel/drivers/rtc.rs
+++ b/kernel/drivers/rtc.rs
@@ -10,16 +10,16 @@ fn cvt_bcd(value: usize) -> usize {
 
 /// RTC
 pub struct Rtc {
-    addr: Pio8,
-    data: Pio8,
+    addr: Pio<u8>,
+    data: Pio<u8>,
 }
 
 impl Rtc {
     /// Create new empty RTC
     pub fn new() -> Self {
         return Rtc {
-            addr: Pio8::new(0x70),
-            data: Pio8::new(0x71),
+            addr: Pio::<u8>::new(0x70),
+            data: Pio::<u8>::new(0x71),
         };
     }
 

--- a/kernel/drivers/serial.rs
+++ b/kernel/drivers/serial.rs
@@ -26,16 +26,14 @@ pub struct Serial {
 impl Serial {
     /// Create new
     pub fn new(port: u16, irq: u8) -> Box<Self> {
-        unsafe {
-            Pio::<u8>::new(port + 1).write(0x00);
-            Pio::<u8>::new(port + 3).write(0x80);
-            Pio::<u8>::new(port + 0).write(0x03);
-            Pio::<u8>::new(port + 1).write(0x00);
-            Pio::<u8>::new(port + 3).write(0x03);
-            Pio::<u8>::new(port + 2).write(0xC7);
-            Pio::<u8>::new(port + 4).write(0x0B);
-            Pio::<u8>::new(port + 1).write(0x01);
-        }
+        Pio::<u8>::new(port + 1).write(0x00);
+        Pio::<u8>::new(port + 3).write(0x80);
+        Pio::<u8>::new(port + 0).write(0x03);
+        Pio::<u8>::new(port + 1).write(0x00);
+        Pio::<u8>::new(port + 3).write(0x03);
+        Pio::<u8>::new(port + 2).write(0xC7);
+        Pio::<u8>::new(port + 4).write(0x0B);
+        Pio::<u8>::new(port + 1).write(0x01);
 
         box Serial {
             data: Pio::<u8>::new(port),
@@ -50,11 +48,11 @@ impl Serial {
 impl KScheme for Serial {
     fn on_irq(&mut self, irq: u8) {
         if irq == self.irq {
-            while unsafe { self.status.read() } & 1 == 0 {
+            while self.status.read() & 1 == 0 {
                 break;
             }
 
-            let mut c = unsafe { self.data.read() } as char;
+            let mut c = self.data.read() as char;
             let mut sc = 0;
 
             if self.escape {

--- a/kernel/drivers/serial.rs
+++ b/kernel/drivers/serial.rs
@@ -16,8 +16,8 @@ const SERIALINFO: *const SerialInfo = 0x400 as *const SerialInfo;
 
 /// Serial
 pub struct Serial {
-    pub data: Pio8,
-    pub status: Pio8,
+    pub data: Pio<u8>,
+    pub status: Pio<u8>,
     pub irq: u8,
     pub escape: bool,
     pub cursor_control: bool,
@@ -27,19 +27,19 @@ impl Serial {
     /// Create new
     pub fn new(port: u16, irq: u8) -> Box<Self> {
         unsafe {
-            Pio8::new(port + 1).write(0x00);
-            Pio8::new(port + 3).write(0x80);
-            Pio8::new(port + 0).write(0x03);
-            Pio8::new(port + 1).write(0x00);
-            Pio8::new(port + 3).write(0x03);
-            Pio8::new(port + 2).write(0xC7);
-            Pio8::new(port + 4).write(0x0B);
-            Pio8::new(port + 1).write(0x01);
+            Pio::<u8>::new(port + 1).write(0x00);
+            Pio::<u8>::new(port + 3).write(0x80);
+            Pio::<u8>::new(port + 0).write(0x03);
+            Pio::<u8>::new(port + 1).write(0x00);
+            Pio::<u8>::new(port + 3).write(0x03);
+            Pio::<u8>::new(port + 2).write(0xC7);
+            Pio::<u8>::new(port + 4).write(0x0B);
+            Pio::<u8>::new(port + 1).write(0x01);
         }
 
         box Serial {
-            data: Pio8::new(port),
-            status: Pio8::new(port + 5),
+            data: Pio::<u8>::new(port),
+            status: Pio::<u8>::new(port + 5),
             irq: irq,
             escape: false,
             cursor_control: false,

--- a/kernel/env/console.rs
+++ b/kernel/env/console.rs
@@ -3,7 +3,7 @@ use alloc::boxed::Box;
 use collections::String;
 use collections::Vec;
 
-use drivers::pio::Pio8;
+use drivers::pio::{Pio,ReadWrite};
 
 use graphics::color::Color;
 use graphics::display::Display;
@@ -167,8 +167,8 @@ impl Console {
     }
 
     pub fn write(&mut self, bytes: &[u8]) {
-        let serial_status = Pio8::new(0x3F8 + 5);
-        let mut serial_data = Pio8::new(0x3F8);
+        let serial_status = Pio::<u8>::new(0x3F8 + 5);
+        let mut serial_data = Pio::<u8>::new(0x3F8);
 
         for byte in bytes.iter() {
             let c = *byte as char;
@@ -180,14 +180,14 @@ impl Console {
             }
 
             unsafe {
-                while serial_status.read() & 0x20 == 0 {}
+                while !serial_status.readf(0x20) {}
                 serial_data.write(*byte);
 
                 if *byte == 8 {
-                    while serial_status.read() & 0x20 == 0 {}
+                    while !serial_status.readf(0x20) {}
                     serial_data.write(0x20);
 
-                    while serial_status.read() & 0x20 == 0 {}
+                    while !serial_status.readf(0x20) {}
                     serial_data.write(8);
                 }
             }

--- a/kernel/env/console.rs
+++ b/kernel/env/console.rs
@@ -179,17 +179,15 @@ impl Console {
                 self.character(c);
             }
 
-            unsafe {
+            while !serial_status.readf(0x20) {}
+            serial_data.write(*byte);
+
+            if *byte == 8 {
                 while !serial_status.readf(0x20) {}
-                serial_data.write(*byte);
+                serial_data.write(0x20);
 
-                if *byte == 8 {
-                    while !serial_status.readf(0x20) {}
-                    serial_data.write(0x20);
-
-                    while !serial_status.readf(0x20) {}
-                    serial_data.write(8);
-                }
+                while !serial_status.readf(0x20) {}
+                serial_data.write(8);
             }
         }
         // If contexts disabled, probably booting up

--- a/kernel/main.rs
+++ b/kernel/main.rs
@@ -443,10 +443,10 @@ pub extern "cdecl" fn kernel(interrupt: usize, mut regs: &mut Regs) {
 
     if interrupt >= 0x20 && interrupt < 0x30 {
         if interrupt >= 0x28 {
-            unsafe { Pio8::new(0xA0).write(0x20) };
+            unsafe { Pio::<u8>::new(0xA0).write(0x20) };
         }
 
-        unsafe { Pio8::new(0x20).write(0x20) };
+        unsafe { Pio::<u8>::new(0x20).write(0x20) };
     }
 
     //Do not catch init interrupt

--- a/kernel/main.rs
+++ b/kernel/main.rs
@@ -443,10 +443,10 @@ pub extern "cdecl" fn kernel(interrupt: usize, mut regs: &mut Regs) {
 
     if interrupt >= 0x20 && interrupt < 0x30 {
         if interrupt >= 0x28 {
-            unsafe { Pio::<u8>::new(0xA0).write(0x20) };
+            Pio::<u8>::new(0xA0).write(0x20);
         }
 
-        unsafe { Pio::<u8>::new(0x20).write(0x20) };
+        Pio::<u8>::new(0x20).write(0x20);
     }
 
     //Do not catch init interrupt

--- a/kernel/network/rtl8139.rs
+++ b/kernel/network/rtl8139.rs
@@ -273,13 +273,11 @@ impl KScheme for Rtl8139 {
 
     fn on_irq(&mut self, irq: u8) {
         if irq == self.irq {
-            unsafe {
-                let isr = self.port.isr.read();
-                self.port.isr.write(isr);
+            let isr = self.port.isr.read();
+            self.port.isr.write(isr);
 
-                // dh(isr as usize);
-                // dl();
-            }
+            // dh(isr as usize);
+            // dl();
 
             self.sync();
         }

--- a/kernel/network/rtl8139.rs
+++ b/kernel/network/rtl8139.rs
@@ -47,42 +47,42 @@ const RTL8139_RCR_APM: u32 = 1 << 1;
 
 #[repr(packed)]
 struct Txd {
-    pub address_port: Pio32,
-    pub status_port: Pio32,
+    pub address_port: Pio<u32>,
+    pub status_port: Pio<u32>,
     pub buffer: usize,
 }
 
 pub struct Rtl8139Port {
-    pub idr: [Pio8; 6],
-    pub rbstart: Pio32,
-    pub cr: Pio8,
-    pub capr: Pio16,
-    pub cbr: Pio16,
-    pub imr: Pio16,
-    pub isr: Pio16,
-    pub tcr: Pio32,
-    pub rcr: Pio32,
-    pub config1: Pio8,
+    pub idr: [Pio<u8>; 6],
+    pub rbstart: Pio<u32>,
+    pub cr: Pio<u8>,
+    pub capr: Pio<u16>,
+    pub cbr: Pio<u16>,
+    pub imr: Pio<u16>,
+    pub isr: Pio<u16>,
+    pub tcr: Pio<u32>,
+    pub rcr: Pio<u32>,
+    pub config1: Pio<u8>,
 }
 
 impl Rtl8139Port {
     pub fn new(base: u16) -> Self {
         return Rtl8139Port {
-            idr: [Pio8::new(base + 0x00),
-                  Pio8::new(base + 0x01),
-                  Pio8::new(base + 0x02),
-                  Pio8::new(base + 0x03),
-                  Pio8::new(base + 0x04),
-                  Pio8::new(base + 0x05)],
-            rbstart: Pio32::new(base + 0x30),
-            cr: Pio8::new(base + 0x37),
-            capr: Pio16::new(base + 0x38),
-            cbr: Pio16::new(base + 0x3A),
-            imr: Pio16::new(base + 0x3C),
-            isr: Pio16::new(base + 0x3E),
-            tcr: Pio32::new(base + 0x40),
-            rcr: Pio32::new(base + 0x44),
-            config1: Pio8::new(base + 0x52),
+            idr: [Pio::<u8>::new(base + 0x00),
+                  Pio::<u8>::new(base + 0x01),
+                  Pio::<u8>::new(base + 0x02),
+                  Pio::<u8>::new(base + 0x03),
+                  Pio::<u8>::new(base + 0x04),
+                  Pio::<u8>::new(base + 0x05)],
+            rbstart: Pio::<u32>::new(base + 0x30),
+            cr: Pio::<u8>::new(base + 0x37),
+            capr: Pio::<u16>::new(base + 0x38),
+            cbr: Pio::<u16>::new(base + 0x3A),
+            imr: Pio::<u16>::new(base + 0x3C),
+            isr: Pio::<u16>::new(base + 0x3E),
+            tcr: Pio::<u32>::new(base + 0x40),
+            rcr: Pio::<u32>::new(base + 0x44),
+            config1: Pio::<u8>::new(base + 0x52),
         };
     }
 }
@@ -164,8 +164,8 @@ impl Rtl8139 {
 
         for i in 0..4 {
             self.txds.push(Txd {
-                address_port: Pio32::new(base + 0x20 + (i as u16) * 4),
-                status_port: Pio32::new(base + 0x10 + (i as u16) * 4),
+                address_port: Pio::<u32>::new(base + 0x20 + (i as u16) * 4),
+                status_port: Pio::<u32>::new(base + 0x10 + (i as u16) * 4),
                 buffer: memory::alloc(4096),
             });
         }

--- a/kernel/syscall/handle.rs
+++ b/kernel/syscall/handle.rs
@@ -57,8 +57,8 @@ pub fn do_sys_debug(ptr: *const u8, len: usize) {
     if unsafe { ::ENV_PTR.is_some() } {
         ::env().console.lock().write(bytes);
     } else {
-        let serial_status = Pio8::new(0x3F8 + 5);
-        let mut serial_data = Pio8::new(0x3F8);
+        let serial_status = Pio::<u8>::new(0x3F8 + 5);
+        let mut serial_data = Pio::<u8>::new(0x3F8);
 
         for byte in bytes.iter() {
             while unsafe { serial_status.read() } & 0x20 == 0 {}

--- a/kernel/syscall/handle.rs
+++ b/kernel/syscall/handle.rs
@@ -61,21 +61,15 @@ pub fn do_sys_debug(ptr: *const u8, len: usize) {
         let mut serial_data = Pio::<u8>::new(0x3F8);
 
         for byte in bytes.iter() {
-            while unsafe { serial_status.read() } & 0x20 == 0 {}
-            unsafe {
-                serial_data.write(*byte);
-            }
+            while !serial_status.readf(0x20) {}
+            serial_data.write(*byte);
 
             if *byte == 8 {
-                while unsafe { serial_status.read() } & 0x20 == 0 {}
-                unsafe {
-                    serial_data.write(0x20);
-                }
+                while !serial_status.readf(0x20) {}
+                serial_data.write(0x20);
 
-                while unsafe { serial_status.read() } & 0x20 == 0 {}
-                unsafe {
-                    serial_data.write(8);
-                }
+                while !serial_status.readf(0x20) {}
+                serial_data.write(8);
             }
         }
     }

--- a/kernel/usb/uhci.rs
+++ b/kernel/usb/uhci.rs
@@ -223,7 +223,7 @@ impl Hci for Uhci {
             };
 
             let frnum = Pio::<u16>::new(self.base as u16 + 6);
-            let frame = (unsafe { frnum.read() } + 1) & 0x3FF;
+            let frame = (frnum.read() + 1) & 0x3FF;
             unsafe { self.frame_list.write(frame as usize, frame_ptr) };
 
             for td in tds.iter().rev() {

--- a/kernel/usb/uhci.rs
+++ b/kernel/usb/uhci.rs
@@ -222,7 +222,7 @@ impl Hci for Uhci {
                 (&*queue_head as *const Qh) as u32 | 2
             };
 
-            let frnum = Pio16::new(self.base as u16 + 6);
+            let frnum = Pio::<u16>::new(self.base as u16 + 6);
             let frame = (unsafe { frnum.read() } + 1) & 0x3FF;
             unsafe { self.frame_list.write(frame as usize, frame_ptr) };
 


### PR DESCRIPTION
While working on PCI stuff I noticed that while MMIO is implemented as generics, PIO isn't. Since I am trying to use generics in PCI code as well I thought it is a good opportunity to convert the PIO to use generics as well. [*Little did I knew about how to do it right. However, I am glad I went through it as I learned a lot. Special thanks to @Ticki for helping me out!*]

Anyway,
this work is splitted into 5 commits. Each does only one thing for the ease of review. I do appreciate review by the way.

I believe the new interface in pio.rs is a little bit cleaner. And it resembles mmio.rs now, which is nice. I think I will be able to unify it even more eventually.

Also as a nice side effect I was able to drop some number of ```unsafe``` blocks.
