### PR TITLE
Fix outdated instructions on running without KVM

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -204,7 +204,7 @@ endMessage()
 	echo "		make virtualbox or qemu"
 	echo
 	echo "If make qemu fails complaining about kvm"
-	echo "run \'make qemu_no_kvm\'"
+	echo "run \'make qemu kvm=no\'"
 	echo
 	echo "      Good luck!"
 


### PR DESCRIPTION
I think this is the last place where ```qemu_no_kvm``` is mentioned as a current way of running it.