### PR TITLE
Simplify the GetSlice implementation

### DIFF
--- a/kernel/common/parse_ip.rs
+++ b/kernel/common/parse_ip.rs
@@ -19,10 +19,14 @@ pub fn parse_port(string: &str) -> &str {
         }
     }
 
-    string.get_slice(string.find(':').map(|a| a + 1), Some(b))
+    if let Some(a) = string.find(':').map(|a| a + 1) {
+        string.get_slice(a..b)
+    } else {
+        string.get_slice(..b)
+    }
 }
 
 /// Get the host from a string (ip)
 pub fn parse_host(string: &str) -> &str {
-    string.get_slice(None, string.find(|c| c == ':' || c == '/').map(|b| b + 1))
+    string.get_slice(..string.find(|c| c == ':' || c == '/').map(|b| b + 1).unwrap_or(0))
 }

--- a/kernel/common/to_num.rs
+++ b/kernel/common/to_num.rs
@@ -43,7 +43,7 @@ impl ToNum for str {
     /// Parse the string as a signed integer using a given radix
     fn to_num_radix_signed(&self, radix: usize) -> isize {
         if self.starts_with('-') {
-            -(self.get_slice(Some(1), None).to_num_radix(radix) as isize)
+            -(self.get_slice(1..).to_num_radix(radix) as isize)
         } else {
             self.to_num_radix(radix) as isize
         }

--- a/kernel/fs/redoxfs/mod.rs
+++ b/kernel/fs/redoxfs/mod.rs
@@ -87,7 +87,7 @@ impl FileSystem {
 
         for node in self.nodes.iter() {
             if node.name.starts_with(directory) {
-                ret.push(node.name.get_slice(Some(directory.len()), None).to_string());
+                ret.push(node.name.get_slice(directory.len()..).to_string());
             }
         }
 

--- a/kernel/main.rs
+++ b/kernel/main.rs
@@ -19,6 +19,8 @@
 #![feature(unwind_attributes)]
 #![feature(vec_push_all)]
 #![feature(zero_one)]
+#![feature(collections_range)]
+#![feature(old_wrapping)]
 #![no_std]
 
 #[macro_use]

--- a/kernel/scheduler/context.rs
+++ b/kernel/scheduler/context.rs
@@ -514,15 +514,14 @@ impl Context {
         if path.find(':').is_none() {
             let cwd = &*self.cwd.get();
             if path.starts_with("../") {
-                cwd.get_slice(None,
-                              Some(cwd.get_slice(None, Some(cwd.len() - 1))
-                                      .rfind('/')
-                                      .map_or(cwd.len(), |i| i + 1)))
-                   .to_string() + &path.get_slice(Some(3), None)
+                cwd.get_slice(..cwd.get_slice(..cwd.len() - 1)
+                                   .rfind('/')
+                                   .map_or(cwd.len(), |i| i + 1))
+                   .to_string() + &path.get_slice(3..)
             } else if path.starts_with("./") {
-                cwd.to_string() + &path.get_slice(Some(2), None)
+                cwd.to_string() + &path.get_slice(2..)
             } else if path.starts_with('/') {
-                cwd.get_slice(None, Some(cwd.find(':').map_or(1, |i| i + 1))).to_string() + &path
+                cwd.get_slice(..cwd.find(':').map_or(1, |i| i + 1)).to_string() + &path
             } else {
                 cwd.to_string() + &path
             }

--- a/kernel/schemes/file.rs
+++ b/kernel/schemes/file.rs
@@ -260,7 +260,7 @@ impl KScheme for FileScheme {
                 let mut line = String::new();
                 match file.find('/') {
                     Some(index) => {
-                        let dirname = file.get_slice(None, Some(index + 1)).to_string();
+                        let dirname = file.get_slice(..index + 1).to_string();
                         let mut found = false;
                         for dir in dirs.iter() {
                             if dirname == *dir {

--- a/kernel/schemes/mod.rs
+++ b/kernel/schemes/mod.rs
@@ -8,6 +8,7 @@ use collections::vec::Vec;
 use core::cmp::{min, max};
 
 use syscall::{Error, O_CREAT, O_RDWR, O_TRUNC, EBADF, ENOENT};
+use env;
 
 /// Context scheme
 pub mod context;
@@ -99,7 +100,7 @@ pub trait Resource {
                 Ok(0) => return Ok(read),
                 Err(err) => return Err(err),
                 Ok(count) => {
-                    vec.push_all(bytes.get_slice(None, Some(count)));
+                    vec.push_all(bytes.get_slice(..count));
                     read += count;
                 }
             }
@@ -140,22 +141,22 @@ impl Url {
 
     /// Open this URL (returns a resource)
     pub fn open(&self) -> Result<Box<Resource>> {
-        ::env().open(&self, O_RDWR)
+        env().open(&self, O_RDWR)
     }
 
     /// Create this URL (returns a resource)
     pub fn create(&self) -> Result<Box<Resource>> {
-        ::env().open(&self, O_CREAT | O_RDWR | O_TRUNC)
+        env().open(&self, O_CREAT | O_RDWR | O_TRUNC)
     }
 
     /// Return the scheme of this url
     pub fn scheme(&self) -> &str {
-        self.string.get_slice(None, self.string.find(':'))
+        self.string.get_slice(..self.string.find(':').unwrap_or(self.string.len()))
     }
 
     /// Get the reference (after the ':') of the url
     pub fn reference(&self) -> &str {
-        self.string.get_slice(self.string.find(':').map(|a| a + 1), None)
+        self.string.get_slice(self.string.find(':').map(|a| a + 1).unwrap_or(0)..)
     }
 
 }

--- a/libstd/src/lib.rs
+++ b/libstd/src/lib.rs
@@ -30,6 +30,7 @@
 #![feature(box_patterns)]
 #![feature(vec_push_all)]
 #![feature(prelude_import)]
+#![feature(old_wrapping)]
 #![feature(type_ascription)]
 #![feature(oom)]
 #![feature(unique)]


### PR DESCRIPTION
Entails:

- Let it take a type implementing `RangeArguments` (you can use the range syntax, `a..b`, `a..`, `..b` and `..`).
- Slightly faster by using branches and comparations
- A bit simpler code

cc @stratact