### PR TITLE
x86_64 interrupt handling

### DIFF
--- a/kernel/asm/interrupts-x86_64.asm
+++ b/kernel/asm/interrupts-x86_64.asm
@@ -7,11 +7,12 @@ struc IDTEntry
 		.ring1	equ 1 << 5
 		.ring2 equ 1 << 6
 		.ring3 equ 1 << 5 | 1 << 6
-		.task32 equ 0x5
-		.interrupt16 equ 0x6
-		.trap16 equ 0x7
-		.interrupt32 equ 0xE
-		.trap32 equ 0xF
+		.ldt32 equ 0x2
+		.tssAvailabe64 equ 0x9
+		.tssBusy64 equ 0xB
+		.callGate64 equ 0xC
+		.interrupt64 equ 0xE
+		.trap64 equ 0xF
 	.offsetm resw 1
 	.offseth resd 1
 	.zero2 resd 1
@@ -55,7 +56,7 @@ interrupts:
 
 	mov rdi, qword [0x100000]
 	mov rsi, rsp
-	
+
 		;Stack Align
 		mov rbp, rsp
 		and rsp, 0xFFFFFFFFFFFFFFF0
@@ -102,9 +103,9 @@ idt:
 %rep 128
 	istruc IDTEntry
 		at IDTEntry.offsetl, dw interrupts+(interrupts.second-interrupts.first)*i
-		at IDTEntry.selector, dw 0x08
+		at IDTEntry.selector, dw gdt.kernel_code
 		at IDTEntry.zero1, db 0
-		at IDTEntry.attribute, db IDTEntry.present | IDTEntry.interrupt32
+		at IDTEntry.attribute, db IDTEntry.present | IDTEntry.interrupt64
 		at IDTEntry.offsetm, dw 0
 		at IDTEntry.offseth, dd 0
 		at IDTEntry.zero2, dd 0
@@ -115,9 +116,9 @@ idt:
 ;Syscall
 istruc IDTEntry
 	at IDTEntry.offsetl, dw interrupts+(interrupts.second-interrupts.first)*i
-	at IDTEntry.selector, dw 0x08
+	at IDTEntry.selector, dw gdt.kernel_code
 	at IDTEntry.zero1, db 0
-	at IDTEntry.attribute, db IDTEntry.ring3 | IDTEntry.present | IDTEntry.interrupt32
+	at IDTEntry.attribute, db IDTEntry.ring3 | IDTEntry.present | IDTEntry.interrupt64
 	at IDTEntry.offsetm, dw 0
 	at IDTEntry.offseth, dd 0
 	at IDTEntry.zero2, dd 0
@@ -128,9 +129,9 @@ iend
 %rep 127
 	istruc IDTEntry
 		at IDTEntry.offsetl, dw interrupts+(interrupts.second-interrupts.first)*i
-		at IDTEntry.selector, dw 0x08
+		at IDTEntry.selector, dw gdt.kernel_code
 		at IDTEntry.zero1, db 0
-		at IDTEntry.attribute, db IDTEntry.present | IDTEntry.interrupt32
+		at IDTEntry.attribute, db IDTEntry.present | IDTEntry.interrupt64
 		at IDTEntry.offsetm, dw 0
 		at IDTEntry.offseth, dd 0
 		at IDTEntry.zero2, dd 0

--- a/kernel/asm/interrupts-x86_64.asm
+++ b/kernel/asm/interrupts-x86_64.asm
@@ -1,10 +1,10 @@
 struc IDTEntry
 	.offsetl resw 1
 	.selector resw 1
-	.zero1 resb 1
+	.ist resb 1
 	.attribute resb 1
 		.present equ 1 << 7
-		.ring1	equ 1 << 5
+		.ring1 equ 1 << 5
 		.ring2 equ 1 << 6
 		.ring3 equ 1 << 5 | 1 << 6
 		.ldt32 equ 0x2
@@ -15,7 +15,7 @@ struc IDTEntry
 		.trap64 equ 0xF
 	.offsetm resw 1
 	.offseth resd 1
-	.zero2 resd 1
+	.reserved resd 1
 endstruc
 
 [section .text]
@@ -104,11 +104,11 @@ idt:
 	istruc IDTEntry
 		at IDTEntry.offsetl, dw interrupts+(interrupts.second-interrupts.first)*i
 		at IDTEntry.selector, dw gdt.kernel_code
-		at IDTEntry.zero1, db 0
+		at IDTEntry.ist, db 0
 		at IDTEntry.attribute, db IDTEntry.present | IDTEntry.interrupt64
 		at IDTEntry.offsetm, dw 0
 		at IDTEntry.offseth, dd 0
-		at IDTEntry.zero2, dd 0
+		at IDTEntry.reserved, dd 0
 	iend
 %assign i i+1
 %endrep
@@ -117,11 +117,11 @@ idt:
 istruc IDTEntry
 	at IDTEntry.offsetl, dw interrupts+(interrupts.second-interrupts.first)*i
 	at IDTEntry.selector, dw gdt.kernel_code
-	at IDTEntry.zero1, db 0
-	at IDTEntry.attribute, db IDTEntry.ring3 | IDTEntry.present | IDTEntry.interrupt64
+	at IDTEntry.ist, db 0
+	at IDTEntry.attribute, db IDTEntry.present | IDTEntry.interrupt64
 	at IDTEntry.offsetm, dw 0
 	at IDTEntry.offseth, dd 0
-	at IDTEntry.zero2, dd 0
+	at IDTEntry.reserved, dd 0
 iend
 %assign i i+1
 
@@ -130,11 +130,11 @@ iend
 	istruc IDTEntry
 		at IDTEntry.offsetl, dw interrupts+(interrupts.second-interrupts.first)*i
 		at IDTEntry.selector, dw gdt.kernel_code
-		at IDTEntry.zero1, db 0
+		at IDTEntry.ist, db 0
 		at IDTEntry.attribute, db IDTEntry.present | IDTEntry.interrupt64
 		at IDTEntry.offsetm, dw 0
 		at IDTEntry.offseth, dd 0
-		at IDTEntry.zero2, dd 0
+		at IDTEntry.reserved, dd 0
 	iend
 %assign i i+1
 %endrep

--- a/kernel/asm/startup-x86_64.asm
+++ b/kernel/asm/startup-x86_64.asm
@@ -92,7 +92,7 @@ long_mode:
 
     mov rax, gdt.tss
     ltr ax
-    xchg bx, bx
+
     ;rust init
     xor rax, rax
     mov [0x100000], rax

--- a/kernel/asm/startup-x86_64.asm
+++ b/kernel/asm/startup-x86_64.asm
@@ -96,7 +96,7 @@ long_mode:
     ;rust init
     xor rax, rax
     mov [0x100000], rax
-    mov eax, [kernel_file + 0x18]
+    mov rax, [kernel_file + 0x18]
     mov [interrupts.handler], rax
     mov rax, tss
     int 0xFF

--- a/kernel/asm/startup-x86_64.asm
+++ b/kernel/asm/startup-x86_64.asm
@@ -97,6 +97,7 @@ long_mode:
     xor rax, rax
     mov [0x100000], rax
     mov rax, [kernel_file + 0x18]
+    add rax, kernel_file
     mov [interrupts.handler], rax
     mov rax, tss
     int 0xFF

--- a/kernel/asm/startup-x86_64.asm
+++ b/kernel/asm/startup-x86_64.asm
@@ -1,5 +1,3 @@
-%define break xchg bx, bx
-
 startup:
   ; a20
   in al, 0x92
@@ -95,7 +93,6 @@ long_mode:
     mov rax, gdt.tss
     ltr ax
 
-    break
     ;rust init
     xor rax, rax
     mov [0x100000], rax

--- a/kernel/asm/startup-x86_64.asm
+++ b/kernel/asm/startup-x86_64.asm
@@ -92,7 +92,7 @@ long_mode:
 
     mov rax, gdt.tss
     ltr ax
-
+    xchg bx, bx
     ;rust init
     xor rax, rax
     mov [0x100000], rax
@@ -140,10 +140,7 @@ struc GDTEntry
         .data_reserved equ 1 << 5
     .baseh resb 1
 endstruc
-struc GDTEntry64
-    .extended_address resd 1
-    .reserved resd 1
-endstruc
+
 gdtr:
     dw gdt.end + 1  ; size
     dq gdt          ; offset


### PR DESCRIPTION
1. I don't know why there was kernel relocation code. on i386 there is none. And the relocation code as it was did quite some garbage. That's why i removed it.
It moved the memory from kernel_file + 0xB000 to kernel_file, so overwrote the kernel, and afterwards cleared 0xB000 Bytes from the end of the - now overwritten - kernel. And this memory is taken from 0x80000+ where there could be some parts from EBDA, which could have led to the Page Fault. Tried to move the kernel to some higher address(1MB+) and it worked, but i don't know if this memory is used elsewhere, and i don't see the purpose in moving the kernel. If this is needed for something and someone knows where to place the kernel, i'd be happy to put the code back.

2. Where does this MagicValue(tm) 0x18 come from? in

        mov eax, [kernel_file + 0x18]
        mov [interrupts.handler], rax

    It works on i386 but on x86_64 it points in the midst of zeroed memory

3. Interrupts are working now, the page fault experienced before was due to writing to protected lower memory (my theory, see above) and the kernel exception handler wasn't yet set up, which led to a triple fault.

tl;dr: We have interrupts, but I don't know where the kernel interrupt handler lives, so we can't do much with those interrupts.