### PR TITLE
docgen - a manpage generator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -283,6 +283,17 @@ doc/std: libstd/src/lib.rs libstd/src/*.rs libstd/src/*/*.rs libstd/src/*/*/*.rs
 
 doc: doc/kernel doc/std
 
+man: filesystem/man
+
+filesystem/man:
+	mkdir man \
+	rm -rf filesystem/man |& true \
+	cd crates/docgen \
+	cargo build --release \
+	cd ../../ \
+	./crates/docgen/target/release/docgen \
+	mv man filesystem
+
 $(BUILD)/libcore.rlib: rust/src/libcore/lib.rs
 	$(MKDIR) -p $(BUILD)
 	$(RUSTC) $(RUSTCFLAGS) --cfg disable_float -o $@ $<

--- a/crates/docgen/Cargo.lock
+++ b/crates/docgen/Cargo.lock
@@ -1,0 +1,35 @@
+[root]
+name = "docgen"
+version = "0.1.0"
+dependencies = [
+ "walkdir 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "kernel32-sys"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "walkdir"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "winapi"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi-build"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+

--- a/crates/docgen/Cargo.toml
+++ b/crates/docgen/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "docgen"
+version = "0.1.0"
+authors = ["Ticki <Ticki@users.noreply.github.com>"]
+
+[dependencies]
+walkdir = "0.1"

--- a/crates/docgen/src/main.rs
+++ b/crates/docgen/src/main.rs
@@ -1,0 +1,42 @@
+#![feature(unicode)]
+
+extern crate walkdir;
+extern crate rustc_unicode;
+
+use walkdir::WalkDir;
+use std::fs::File;
+use std::io::prelude::*;
+
+fn main() {
+    for entry in WalkDir::new(".").follow_links(true).into_iter().map(|x| x.expect("Couldn't walk dir.")).filter(|x| x.file_type().is_file()) {
+        let mut string = String::new();
+
+        File::open(entry.path()).expect("Could't open file.")
+                                .read_to_string(&mut string)
+                                .expect("Could't read file.");
+
+        for i in string.split("@MANSTART{").skip(1) {
+            let end_delimiter = i.find('}').expect("Unclosed '{'");
+            let name = &i[..end_delimiter];
+            assert!(name.lines().count() == 1, "malformed manpage name");
+
+            let mut man_page = &i[end_delimiter + 1..i.find("@MANEND")
+                                                      .expect("Unclosed @MANSTART (use @MANEND).")].trim();
+
+            let mut string = String::with_capacity(man_page.len() + man_page.len() / 3);
+
+            for i in man_page.lines() {
+                string.push_str(i.trim_left_matches('\\')
+                                 .trim_left_matches("// ")
+                                 .trim_left_matches("//! ")
+                                 .trim_left_matches("/// ")
+                                 .trim_left_matches("->")
+                                 .trim_left_matches("<!-"));
+                string.push('\n')
+            }
+
+            let mut file = File::create("man/".to_owned() + name).expect("Couldn't create man page.");
+            file.write(&string.as_bytes()[1..string.len() - 1]).expect("Couldn't write man page.");
+        }
+    }
+}

--- a/crates/docgen/src/test/man/doc-ml
+++ b/crates/docgen/src/test/man/doc-ml
@@ -1,0 +1,3 @@
+test doc mode
+myltiline
+Oh, snap.

--- a/crates/docgen/src/test/man/test1
+++ b/crates/docgen/src/test/man/test1
@@ -1,0 +1,1 @@
+ere you go

--- a/crates/docgen/src/test/man/test2
+++ b/crates/docgen/src/test/man/test2
@@ -1,0 +1,1 @@
+eah test 2

--- a/crates/docgen/src/test/test.txt
+++ b/crates/docgen/src/test/test.txt
@@ -1,0 +1,17 @@
+@MANSTART{test1}
+here you go
+@MANEND
+
+@MANSTART{test2}
+yeah test 2
+@MANEND
+
+/// <!- @MANSTART{doc} ->
+/// test doc mode
+/// <!- @MANEND ->
+
+/// <!- @MANSTART{doc-ml} ->
+/// test doc mode
+/// myltiline
+/// Oh, snap.
+/// <!- @MANEND ->


### PR DESCRIPTION
This is a very simple manpage generator. Manpages are extracted from the codebase, and started by `@MANSTART{name}` and ended by `@MANEND`. These are then placed in filesystem/man, which can then later be read using `cat`.