### PR TITLE
Fix out of date package

### DIFF
--- a/setup/arch.sh
+++ b/setup/arch.sh
@@ -8,7 +8,7 @@ sudo pacman -S --needed base-devel nasm lib32-glibc glibc
 
 #Install Virtual Box and Setup
 echo "Installing virtualbox and it's dependencies"
-sudo pacman -S --needed virtualbox virtualbox-host-modules virtualbox-guest-iso qt4
+sudo pacman -S --needed virtualbox virtualbox-host-dkms virtualbox-guest-iso qt4
 
 #Load kernel modules and set for persistence
 echo "Setting up virtualbox for persistence across reboots"


### PR DESCRIPTION
As written here: https://www.archlinux.org/packages/community/x86_64/virtualbox-host-dkms/ virttualbox-host-modules has been replaced by virtualbox-host-dkms. Although we advocate using QEMU and bootstrap installs QEMU regardless, so I am not sure if we should even be installing virtualbox here. Just my thoughts either way this dependency is now fixed.