### PR TITLE
Fix duplicate match case typo in filesystem/ansi-term/buffer.rs

### DIFF
--- a/filesystem/apps/ansi-term/buffer.rs
+++ b/filesystem/apps/ansi-term/buffer.rs
@@ -74,7 +74,7 @@ impl Buffer {
                     self.cursor.goto_x(0);
                 }
             }
-            Action::CursorUp(n) => self.cursor.x = self.cursor.x.saturating_sub(n),
+            Action::CursorLeft(n) => self.cursor.x = self.cursor.x.saturating_sub(n),
             Action::NextLine(n) => {
                 self.cursor.goto_x(0);
                 self.cursor.y += n;


### PR DESCRIPTION
I happened to notice there was what appears to be a typo in filesystem/ansi-term/buffer.rs where CursorUp was matched against twice. 