### PR TITLE
Implement fmt::Debug for std::Command

### DIFF
--- a/libstd/src/process.rs
+++ b/libstd/src/process.rs
@@ -1,5 +1,6 @@
 use boxed::Box;
 use core::mem;
+use fmt;
 use io::{Result, Read, Write};
 use os::unix::io::{AsRawFd, FromRawFd, RawFd};
 use ops::DerefMut;
@@ -104,6 +105,16 @@ pub struct Command {
     stdin: Stdio,
     stdout: Stdio,
     stderr: Stdio,
+}
+
+impl fmt::Debug for Command {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        try!(write!(f, "{:?}", self.path));
+        for arg in &self.args {
+            try!(write!(f, " {:?}", arg));
+        }
+        Ok(())
+    }
 }
 
 impl Command {


### PR DESCRIPTION
Used by https://github.com/redox-os/ion/blob/master/src/pipe.rs#L86.

This PR allows the ion submodule to be updated to redox-os/ion@bb3fe98457e727f8a3ad29447109d0a2dfda5ce0.

However, redox-os/ion@474b97e6046fdaa54dd0e2bccdcc5eb9c8f35712 breaks the build. Should I make an issue for that on this repo, or the ion repo? (I'm assuming it should be this repo, since ion builds fine using the normal libstd, but fails using the redox libstd)