### PR TITLE
GitHub issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE
+++ b/.github/ISSUE_TEMPLATE
@@ -6,7 +6,9 @@
 
 **Build information**: [output of `rustc -V`, `git rev-parse HEAD`, `qemu-i386 -version`, `uname -a`, etc.]
 
-**Misc**: [...]
+**Blocking/related**: [issues or PRs blocking or being related to this issue.]
+
+**Misc**: [optional: for other relevant information that should be known or cannot be described in the other fields.]
 
 ------
 

--- a/.github/ISSUE_TEMPLATE
+++ b/.github/ISSUE_TEMPLATE
@@ -1,0 +1,13 @@
+**Reproduction**: [describe how you are able to reproduce ("trigger") this bug/issue.]
+
+**Expected behavior**: [describe the behavior you would expect the repro to yield.]
+
+**Actual behavior**: [describe the actual behavior, which is presented through the repro.].
+
+**Build information**: [output of `rustc -V`, `git rev-parse HEAD`, `qemu-i386 -version`, `uname -a`, etc.]
+
+**Misc**: [...]
+
+------
+
+_If the above does not fit the nature of the issue feel free to modify it._

--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -16,7 +16,9 @@
 
 **State**: [the state of this PR, e.g. WIP, ready, etc.]
 
-**Other**: [misc information.]
+**Blocking/related**: [issues or PRs blocking or being related to this issue.]
+
+**Other**: [optional: for other relevant information that should be known or cannot be described in the other fields.]
 
 ------
 

--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -1,0 +1,23 @@
+**Problem**: [describe the problem you try to solve with this PR.]
+
+**Solution**: [describe carefully what you change by this PR.]
+
+**Changes introduced by this pull request**:
+
+- [...]
+- [...]
+- [...]
+
+**Drawbacks**: [if any, describe the drawbacks of this pull request.]
+
+**TODOs**: [what is not done yet.]
+
+**Fixes**: [what issues this fixes.]
+
+**State**: [the state of this PR, e.g. WIP, ready, etc.]
+
+**Other**: [misc information.]
+
+------
+
+_The above template is not necessary for smaller PRs._


### PR DESCRIPTION
**Problem**: The PRs tend to be very little descriptive and non-explaining without having to look at the diffs.

**Solution**: Introduce templates to encourage rich information about the changes, to increase quality of the issues and PR descriptions.

**Changes introduced by this pull request**:

- Add a PR template. See [Github's blog post](https://github.com/blog/2111-issue-and-pull-request-templates). This template is to encourage non-small PRs to contain extra useful information about the changes.

- Add an issue template, encouraging users to describe the reproduction steps and the expected behavior.

**Drawbacks**: This might reduce the number of micro PRs (~3 lines), since describing the changes is not a programmers favorite task. In order to combat this, we add a small message in the bottom stating that the description is unnecessary for smaller PRs.

**TODOs**: Possibly improvement to the fields.

**Fixes**: This does not fix any specific issues.

**State**: Ready.

**Blocking/related**: This is a part of the documentation effort going on. Related to #525.