### PR TITLE
Don't try to load non-evisting redoxfs.bin

### DIFF
--- a/filesystem/etc/init.rc
+++ b/filesystem/etc/init.rc
@@ -1,5 +1,5 @@
 # Redox FS, to be moved into initfs
-initfs:redoxfsd /etc/redoxfs.bin
+#initfs:redoxfsd /etc/redoxfs.bin
 
 # Example scheme
 example


### PR DESCRIPTION
**Problem**: [describe the problem you try to solve with this PR.]
Currently redoxfs.bin isn't built for `make all`, thus trying to load /etc/redoxfs.bin at runtime will always fail.

**Solution**: [describe carefully what you change by this PR.]
Don't load redoxfs.bin

**Changes introduced by this pull request**:
remove loading redoxfs.bin

**Drawbacks**: [if any, describe the drawbacks of this pull request.]
If someone is testing redoxfs.bin, he might want to add this line again.