### PR TITLE
Kernel mapping

### DIFF
--- a/crates/orbital/main.rs
+++ b/crates/orbital/main.rs
@@ -463,7 +463,7 @@ fn main() {
     let status_mutex = Arc::new(Mutex::new(Status::Starting));
 
     let status_daemon = status_mutex.clone();
-    let daemon_thread = thread::spawn(move || {
+    thread::spawn(move || {
         match Socket::create(":orbital").map(|socket| Arc::new(socket)) {
             Ok(socket) => match Socket::open("display:manager").map(|display| Arc::new(display)) {
                 Ok(display) => {
@@ -504,7 +504,7 @@ fn main() {
         match *status_mutex.lock().unwrap() {
             Status::Starting => (),
             Status::Running => {
-                Command::new("launcher").spawn().unwrap().wait().unwrap();
+                Command::new("launcher").spawn().unwrap();
                 break 'waiting;
             },
             Status::Stopping => break 'waiting,
@@ -512,6 +512,4 @@ fn main() {
 
         thread::sleep_ms(30);
     }
-
-    daemon_thread.join().unwrap();
 }

--- a/kernel/alloc_system.rs
+++ b/kernel/alloc_system.rs
@@ -1,19 +1,68 @@
 use arch::memory::*;
+use arch::paging::Page;
+
+const LOGICAL_OFFSET: usize = 0x80000000;
 
 #[allocator]
 #[no_mangle]
 pub extern "C" fn __rust_allocate(size: usize, align: usize) -> *mut u8 {
-    unsafe { alloc_aligned(size, align) as *mut u8 }
+    unsafe {
+        let address = alloc_aligned(size, align);
+        if address > 0 {
+            for page in 0..(size + CLUSTER_SIZE - 1)/CLUSTER_SIZE {
+                let physical_address = address + page * CLUSTER_SIZE;
+                let virtual_address = physical_address + LOGICAL_OFFSET;
+                Page::new(virtual_address).map_kernel_write(physical_address);
+            }
+
+            (address + LOGICAL_OFFSET) as *mut u8
+        } else {
+            address as *mut u8
+        }
+    }
 }
 
 #[no_mangle]
-pub extern "C" fn __rust_deallocate(ptr: *mut u8, _old_size: usize, _align: usize) {
-    unsafe { unalloc(ptr as usize) }
+pub extern "C" fn __rust_deallocate(ptr: *mut u8, old_size: usize, _align: usize) {
+    unsafe {
+        let address = ptr as usize - LOGICAL_OFFSET;
+
+        unalloc(address);
+
+        for page in 0..(old_size + CLUSTER_SIZE - 1)/CLUSTER_SIZE {
+            let physical_address = address + page * CLUSTER_SIZE;
+            let virtual_address = physical_address + LOGICAL_OFFSET;
+            Page::new(virtual_address).unmap();
+        }
+    }
 }
 
 #[no_mangle]
-pub extern "C" fn __rust_reallocate(ptr: *mut u8, _old_size: usize, size: usize, align: usize) -> *mut u8 {
-    unsafe { realloc_aligned(ptr as usize, size, align) as *mut u8 }
+pub extern "C" fn __rust_reallocate(ptr: *mut u8, old_size: usize, size: usize, align: usize) -> *mut u8 {
+    unsafe {
+        let old_address = ptr as usize - LOGICAL_OFFSET;
+        let address = realloc_aligned(old_address, size, align);
+
+        if address > 0 {
+            if address != old_address {
+                for page in 0..(old_size + CLUSTER_SIZE - 1)/CLUSTER_SIZE {
+                    let physical_address = old_address + page * CLUSTER_SIZE;
+                    let virtual_address = physical_address + LOGICAL_OFFSET;
+                    Page::new(virtual_address).unmap();
+                }
+
+                for page in 0..(size + CLUSTER_SIZE - 1)/CLUSTER_SIZE {
+                    let physical_address = address + page * CLUSTER_SIZE;
+                    let virtual_address = physical_address + LOGICAL_OFFSET;
+                    Page::new(virtual_address).map_kernel_write(physical_address);
+                }
+            }
+
+            (address + LOGICAL_OFFSET) as *mut u8
+        } else {
+            address as *mut u8
+        }
+    }
 }
 
 #[no_mangle]

--- a/kernel/arch/context.rs
+++ b/kernel/arch/context.rs
@@ -25,8 +25,17 @@ use system::error::{Error, Result, EBADF, EFAULT, ENOMEM, ESRCH};
 
 use sync::WaitMap;
 
-pub const CONTEXT_STACK_SIZE: usize = 1024 * 1024;
-pub const CONTEXT_STACK_ADDR: usize = 0x80000000;
+pub const CONTEXT_IMAGE_ADDR: usize = 0x8048000;
+pub const CONTEXT_IMAGE_SIZE: usize = 0x10000000;
+
+pub const CONTEXT_HEAP_ADDR: usize = CONTEXT_IMAGE_ADDR + CONTEXT_IMAGE_SIZE + CLUSTER_SIZE;
+pub const CONTEXT_HEAP_SIZE: usize = 0x40000000;
+
+pub const CONTEXT_MMAP_ADDR: usize = CONTEXT_HEAP_ADDR + CONTEXT_HEAP_SIZE + CLUSTER_SIZE;
+pub const CONTEXT_MMAP_SIZE: usize = 0x20000000;
+
+pub const CONTEXT_STACK_ADDR: usize = CONTEXT_MMAP_ADDR + CONTEXT_MMAP_SIZE + CLUSTER_SIZE;
+pub const CONTEXT_STACK_SIZE: usize = 0x100000;
 
 pub struct ContextManager {
     pub inner: Vec<Box<Context>>,
@@ -113,7 +122,6 @@ impl ContextManager {
         }
     }
 }
-
 
 /// Switch context
 ///
@@ -418,6 +426,108 @@ pub struct ContextFile {
     pub resource: Box<Resource>,
 }
 
+pub struct ContextMemoryZone {
+    pub addr: usize,
+    pub size: usize,
+    pub memory: Vec<ContextMemory>
+}
+
+impl ContextMemoryZone {
+    pub fn dup(&self) -> ContextMemoryZone {
+        let mut mem: Vec<ContextMemory> = Vec::new();
+        for entry in self.memory.iter() {
+            let physical_address = memory::alloc(entry.virtual_size);
+            if physical_address > 0 {
+                ::memcpy(physical_address as *mut u8,
+                         entry.physical_address as *const u8,
+                         entry.virtual_size);
+
+                //debugln!("{}: {}: dup memory {:X}:{:X} for {}", parent.pid, parent.name, entry.virtual_address, entry.virtual_address + entry.virtual_size, clone_pid);
+
+                mem.push(ContextMemory {
+                    physical_address: physical_address,
+                    virtual_address: entry.virtual_address,
+                    virtual_size: entry.virtual_size,
+                    writeable: entry.writeable,
+                    allocated: true,
+                });
+            } else {
+                //debugln!("{}: {}: failed to dup memory {:X}:{:X} for {}", parent.pid, parent.name, entry.virtual_address, entry.virtual_address + entry.virtual_size, clone_pid);
+            }
+        }
+        ContextMemoryZone {
+            addr: self.addr,
+            size: self.size,
+            memory: mem
+        }
+    }
+
+    /// Get the next available memory map address
+    pub fn next_mem(&self) -> usize {
+        let mut next_mem = 0;
+
+        for mem in self.memory.iter() {
+            let pages = (mem.virtual_size + 4095) / 4096;
+            let end = mem.virtual_address + pages * 4096;
+            if next_mem < end {
+                next_mem = end;
+            }
+        }
+
+        return next_mem;
+    }
+
+    /// Translate to physical if a ptr is inside of the mapped memory
+    pub fn translate(&self, ptr: usize, len: usize) -> Result<usize> {
+        for mem in self.memory.iter() {
+            if ptr >= mem.virtual_address && ptr < mem.virtual_address + mem.virtual_size {
+                return Ok(ptr - mem.virtual_address + mem.physical_address);
+            }
+        }
+
+        Err(Error::new(EFAULT))
+    }
+
+    /// Get a memory map from a pointer
+    pub fn get_mem<'a>(&self, ptr: usize) -> Result<&'a ContextMemory> {
+        for mem in self.memory.iter() } {
+            if mem.virtual_address == ptr {
+                return Ok(mem);
+            }
+        }
+
+        Err(Error::new(ENOMEM))
+    }
+
+    /// Get a mutable memory map from a pointer
+    pub fn get_mem_mut<'a>(&mut self, ptr: usize) -> Result<&'a mut ContextMemory> {
+        for mem in self.memory.iter_mut() {
+            if mem.virtual_address == ptr {
+                return Ok(mem);
+            }
+        }
+
+        Err(Error::new(ENOMEM))
+    }
+
+    /// Cleanup empty memory
+    pub unsafe fn clean_mem(&mut self) {
+        self.memory.retain(|mem| mem.virtual_size > 0);
+    }
+
+    pub unsafe fn map(&mut self) {
+        for entry in self.memory.iter_mut() {
+            entry.map();
+        }
+    }
+
+    pub unsafe fn unmap(&mut self) {
+        for entry in self.memory.iter_mut() {
+            entry.unmap();
+        }
+    }
+}
+
 pub struct Context {
     // These members are used for control purposes by the scheduler {
     // The PID of the context
@@ -456,10 +566,14 @@ pub struct Context {
     // }
 
     // These members are cloned for threads, copied or created for processes {
+    /// Program memory, cloned for threads, copied or created for processes. Modified by exec
+    pub image: Arc<UnsafeCell<ContextMemoryZone>>,
+    /// Heap, cloned for threads, copied or created for processes. Modified by memory allocation
+    pub heap: Arc<UnsafeCell<ContextMemoryZone>>,
+    /// Mmap memory, cloned for threads, copied or created for processes. Modified by mmap
+    pub mmap: Arc<UnsafeCell<ContextMemoryZone>>,
     /// Program working directory, cloned for threads, copied or created for processes. Modified by chdir
     pub cwd: Arc<UnsafeCell<String>>,
-    /// Program memory, cloned for threads, copied or created for processes. Modified by memory allocation
-    pub memory: Arc<UnsafeCell<Vec<ContextMemory>>>,
     /// Program files, cloned for threads, copied or created for processes. Modified by file operations
     pub files: Arc<UnsafeCell<Vec<ContextFile>>>,
     // }
@@ -519,8 +633,11 @@ impl Context {
             stack: None,
             loadable: false,
 
+            image: Arc::new(UnsafeCell::new(Vec::new())),
+            heap: Arc::new(UnsafeCell::new(Vec::new())),
+            mmap: Arc::new(UnsafeCell::new(Vec::new())),
+
             cwd: Arc::new(UnsafeCell::new(String::new())),
-            memory: Arc::new(UnsafeCell::new(Vec::new())),
             files: Arc::new(UnsafeCell::new(Vec::new())),
 
             statuses: WaitMap::new(),
@@ -553,8 +670,11 @@ impl Context {
             stack: None,
             loadable: false,
 
+            image: Arc::new(UnsafeCell::new(Vec::new())),
+            heap: Arc::new(UnsafeCell::new(Vec::new())),
+            mmap: Arc::new(UnsafeCell::new(Vec::new())),
+
             cwd: Arc::new(UnsafeCell::new(String::new())),
-            memory: Arc::new(UnsafeCell::new(Vec::new())),
             files: Arc::new(UnsafeCell::new(Vec::new())),
 
             statuses: WaitMap::new(),
@@ -617,65 +737,6 @@ impl Context {
         }
     }
 
-    /// Get the next available memory map address
-    pub fn next_mem(&self) -> usize {
-        let mut next_mem = 0;
-
-        for mem in unsafe { (*self.memory.get()).iter() } {
-            let pages = (mem.virtual_size + 4095) / 4096;
-            let end = mem.virtual_address + pages * 4096;
-            if next_mem < end {
-                next_mem = end;
-            }
-        }
-
-        return next_mem;
-    }
-
-    /// Translate to physical if a ptr is inside of the mapped memory
-    pub fn translate(&self, ptr: usize, len: usize) -> Result<usize> {
-        if let Some(ref stack) = self.stack {
-            if ptr >= stack.virtual_address && ptr + len <= stack.virtual_address + stack.virtual_size {
-                return Ok(ptr - stack.virtual_address + stack.physical_address);
-            }
-        }
-
-        for mem in unsafe { (*self.memory.get()).iter() } {
-            if ptr >= mem.virtual_address && ptr < mem.virtual_address + mem.virtual_size {
-                return Ok(ptr - mem.virtual_address + mem.physical_address);
-            }
-        }
-
-        Err(Error::new(EFAULT))
-    }
-
-    /// Get a memory map from a pointer
-    pub fn get_mem<'a>(&self, ptr: usize) -> Result<&'a ContextMemory> {
-        for mem in unsafe { (*self.memory.get()).iter() } {
-            if mem.virtual_address == ptr {
-                return Ok(mem);
-            }
-        }
-
-        Err(Error::new(ENOMEM))
-    }
-
-    /// Get a mutable memory map from a pointer
-    pub fn get_mem_mut<'a>(&mut self, ptr: usize) -> Result<&'a mut ContextMemory> {
-        for mem in unsafe { (*self.memory.get()).iter_mut() } {
-            if mem.virtual_address == ptr {
-                return Ok(mem);
-            }
-        }
-
-        Err(Error::new(ENOMEM))
-    }
-
-    /// Cleanup empty memory
-    pub unsafe fn clean_mem(&mut self) {
-        (*self.memory.get()).retain(|mem| mem.virtual_size > 0);
-    }
-
     /// Get the next available file descriptor
     pub fn next_fd(&self) -> usize {
         let mut next_fd = 0;
@@ -724,6 +785,23 @@ impl Context {
     pub unsafe fn push(&mut self, data: usize) {
         self.regs.sp -= mem::size_of::<usize>();
         ptr::write(self.regs.sp as *mut usize, data);
+    }
+
+    /// Translate to physical if a ptr is inside of the mapped memory
+    pub fn translate(&self, ptr: usize, len: usize) -> Result<usize> {
+        if let Some(ref stack) = self.stack {
+            if ptr >= stack.virtual_address && ptr + len <= stack.virtual_address + stack.virtual_size {
+                return Ok(ptr - stack.virtual_address + stack.physical_address);
+            }
+        }
+
+        for mem in unsafe { (*self.memory.get()).iter() } {
+            if ptr >= mem.virtual_address && ptr < mem.virtual_address + mem.virtual_size {
+                return Ok(ptr - mem.virtual_address + mem.physical_address);
+            }
+        }
+
+        Err(Error::new(EFAULT))
     }
 
     pub unsafe fn map(&mut self) {

--- a/kernel/arch/context.rs
+++ b/kernel/arch/context.rs
@@ -28,13 +28,13 @@ use sync::WaitMap;
 pub const CONTEXT_IMAGE_ADDR: usize = 0x8048000;
 pub const CONTEXT_IMAGE_SIZE: usize = 0x10000000;
 
-pub const CONTEXT_HEAP_ADDR: usize = CONTEXT_IMAGE_ADDR + CONTEXT_IMAGE_SIZE + CLUSTER_SIZE;
+pub const CONTEXT_HEAP_ADDR: usize = CONTEXT_IMAGE_ADDR + CONTEXT_IMAGE_SIZE + memory::CLUSTER_SIZE;
 pub const CONTEXT_HEAP_SIZE: usize = 0x40000000;
 
-pub const CONTEXT_MMAP_ADDR: usize = CONTEXT_HEAP_ADDR + CONTEXT_HEAP_SIZE + CLUSTER_SIZE;
+pub const CONTEXT_MMAP_ADDR: usize = CONTEXT_HEAP_ADDR + CONTEXT_HEAP_SIZE + memory::CLUSTER_SIZE;
 pub const CONTEXT_MMAP_SIZE: usize = 0x20000000;
 
-pub const CONTEXT_STACK_ADDR: usize = CONTEXT_MMAP_ADDR + CONTEXT_MMAP_SIZE + CLUSTER_SIZE;
+pub const CONTEXT_STACK_ADDR: usize = CONTEXT_MMAP_ADDR + CONTEXT_MMAP_SIZE + memory::CLUSTER_SIZE;
 pub const CONTEXT_STACK_SIZE: usize = 0x100000;
 
 pub struct ContextManager {
@@ -257,38 +257,31 @@ pub unsafe fn context_clone(regs: &Regs) -> Result<usize> {
                 },
                 loadable: parent.loadable,
 
+                image: if flags & CLONE_VM == CLONE_VM {
+                    //debugln!("{}: {}: clone memory for {}", parent.pid, parent.name, clone_pid);
+
+                    parent.image.clone()
+                } else {
+                    Arc::new(UnsafeCell::new((*parent.image.get()).dup()))
+                },
+                heap: if flags & CLONE_VM == CLONE_VM {
+                    //debugln!("{}: {}: clone memory for {}", parent.pid, parent.name, clone_pid);
+
+                    parent.heap.clone()
+                } else {
+                    Arc::new(UnsafeCell::new((*parent.heap.get()).dup()))
+                },
+                mmap: if flags & CLONE_VM == CLONE_VM {
+                    //debugln!("{}: {}: clone memory for {}", parent.pid, parent.name, clone_pid);
+
+                    parent.mmap.clone()
+                } else {
+                    Arc::new(UnsafeCell::new((*parent.mmap.get()).dup()))
+                },
                 cwd: if flags & CLONE_FS == CLONE_FS {
                     parent.cwd.clone()
                 } else {
                     Arc::new(UnsafeCell::new((*parent.cwd.get()).clone()))
-                },
-                memory: if flags & CLONE_VM == CLONE_VM {
-                    //debugln!("{}: {}: clone memory for {}", parent.pid, parent.name, clone_pid);
-
-                    parent.memory.clone()
-                } else {
-                    let mut mem: Vec<ContextMemory> = Vec::new();
-                    for entry in (*parent.memory.get()).iter() {
-                        let physical_address = memory::alloc(entry.virtual_size);
-                        if physical_address > 0 {
-                            ::memcpy(physical_address as *mut u8,
-                                     entry.physical_address as *const u8,
-                                     entry.virtual_size);
-
-                            //debugln!("{}: {}: dup memory {:X}:{:X} for {}", parent.pid, parent.name, entry.virtual_address, entry.virtual_address + entry.virtual_size, clone_pid);
-
-                            mem.push(ContextMemory {
-                                physical_address: physical_address,
-                                virtual_address: entry.virtual_address,
-                                virtual_size: entry.virtual_size,
-                                writeable: entry.writeable,
-                                allocated: true,
-                            });
-                        } else {
-                            //debugln!("{}: {}: failed to dup memory {:X}:{:X} for {}", parent.pid, parent.name, entry.virtual_address, entry.virtual_address + entry.virtual_size, clone_pid);
-                        }
-                    }
-                    Arc::new(UnsafeCell::new(mem))
                 },
                 files: if flags & CLONE_FILES == CLONE_FILES {
                     //debugln!("{}: {}: clone resources for {}", parent.pid, parent.name, clone_pid);
@@ -426,21 +419,32 @@ pub struct ContextFile {
     pub resource: Box<Resource>,
 }
 
-pub struct ContextMemoryZone {
-    pub addr: usize,
+pub struct ContextZone {
+    pub address: usize,
     pub size: usize,
     pub memory: Vec<ContextMemory>
 }
 
-impl ContextMemoryZone {
-    pub fn dup(&self) -> ContextMemoryZone {
+impl ContextZone {
+    pub fn new(address: usize, size: usize) -> ContextZone {
+        ContextZone {
+            address: address,
+            size: size,
+            memory: Vec::new()
+        }
+    }
+
+    pub fn dup(&self) -> ContextZone {
         let mut mem: Vec<ContextMemory> = Vec::new();
         for entry in self.memory.iter() {
-            let physical_address = memory::alloc(entry.virtual_size);
+            let physical_address = unsafe { memory::alloc(entry.virtual_size) };
             if physical_address > 0 {
-                ::memcpy(physical_address as *mut u8,
-                         entry.physical_address as *const u8,
-                         entry.virtual_size);
+                //TODO: Remap pages during memcpy
+                unsafe {
+                    ::memcpy(physical_address as *mut u8,
+                             entry.physical_address as *const u8,
+                             entry.virtual_size);
+                }
 
                 //debugln!("{}: {}: dup memory {:X}:{:X} for {}", parent.pid, parent.name, entry.virtual_address, entry.virtual_address + entry.virtual_size, clone_pid);
 
@@ -455,16 +459,27 @@ impl ContextMemoryZone {
                 //debugln!("{}: {}: failed to dup memory {:X}:{:X} for {}", parent.pid, parent.name, entry.virtual_address, entry.virtual_address + entry.virtual_size, clone_pid);
             }
         }
-        ContextMemoryZone {
-            addr: self.addr,
+
+        ContextZone {
+            address: self.address,
             size: self.size,
             memory: mem
         }
     }
 
+    pub fn size(&self) -> usize {
+        let mut size = 0;
+
+        for entry in self.memory.iter() {
+            size += entry.virtual_size;
+        }
+
+        size
+    }
+
     /// Get the next available memory map address
     pub fn next_mem(&self) -> usize {
-        let mut next_mem = 0;
+        let mut next_mem = self.address;
 
         for mem in self.memory.iter() {
             let pages = (mem.virtual_size + 4095) / 4096;
@@ -478,19 +493,19 @@ impl ContextMemoryZone {
     }
 
     /// Translate to physical if a ptr is inside of the mapped memory
-    pub fn translate(&self, ptr: usize, len: usize) -> Result<usize> {
+    pub fn translate(&self, ptr: usize, len: usize) -> Option<usize> {
         for mem in self.memory.iter() {
-            if ptr >= mem.virtual_address && ptr < mem.virtual_address + mem.virtual_size {
-                return Ok(ptr - mem.virtual_address + mem.physical_address);
+            if ptr >= mem.virtual_address && ptr + len < mem.virtual_address + mem.virtual_size {
+                return Some(ptr - mem.virtual_address + mem.physical_address);
             }
         }
 
-        Err(Error::new(EFAULT))
+        None
     }
 
     /// Get a memory map from a pointer
-    pub fn get_mem<'a>(&self, ptr: usize) -> Result<&'a ContextMemory> {
-        for mem in self.memory.iter() } {
+    pub fn get_mem<'a>(&'a self, ptr: usize) -> Result<&'a ContextMemory> {
+        for mem in self.memory.iter() {
             if mem.virtual_address == ptr {
                 return Ok(mem);
             }
@@ -500,7 +515,7 @@ impl ContextMemoryZone {
     }
 
     /// Get a mutable memory map from a pointer
-    pub fn get_mem_mut<'a>(&mut self, ptr: usize) -> Result<&'a mut ContextMemory> {
+    pub fn get_mem_mut<'a>(&'a mut self, ptr: usize) -> Result<&'a mut ContextMemory> {
         for mem in self.memory.iter_mut() {
             if mem.virtual_address == ptr {
                 return Ok(mem);
@@ -567,11 +582,12 @@ pub struct Context {
 
     // These members are cloned for threads, copied or created for processes {
     /// Program memory, cloned for threads, copied or created for processes. Modified by exec
-    pub image: Arc<UnsafeCell<ContextMemoryZone>>,
+    pub image: Arc<UnsafeCell<ContextZone>>,
     /// Heap, cloned for threads, copied or created for processes. Modified by memory allocation
-    pub heap: Arc<UnsafeCell<ContextMemoryZone>>,
+    pub heap: Arc<UnsafeCell<ContextZone>>,
     /// Mmap memory, cloned for threads, copied or created for processes. Modified by mmap
-    pub mmap: Arc<UnsafeCell<ContextMemoryZone>>,
+    pub mmap: Arc<UnsafeCell<ContextZone>>,
+
     /// Program working directory, cloned for threads, copied or created for processes. Modified by chdir
     pub cwd: Arc<UnsafeCell<String>>,
     /// Program files, cloned for threads, copied or created for processes. Modified by file operations
@@ -633,9 +649,9 @@ impl Context {
             stack: None,
             loadable: false,
 
-            image: Arc::new(UnsafeCell::new(Vec::new())),
-            heap: Arc::new(UnsafeCell::new(Vec::new())),
-            mmap: Arc::new(UnsafeCell::new(Vec::new())),
+            image: Arc::new(UnsafeCell::new(ContextZone::new(CONTEXT_IMAGE_ADDR, CONTEXT_IMAGE_SIZE))),
+            heap: Arc::new(UnsafeCell::new(ContextZone::new(CONTEXT_HEAP_ADDR, CONTEXT_HEAP_SIZE))),
+            mmap: Arc::new(UnsafeCell::new(ContextZone::new(CONTEXT_MMAP_ADDR, CONTEXT_MMAP_SIZE))),
 
             cwd: Arc::new(UnsafeCell::new(String::new())),
             files: Arc::new(UnsafeCell::new(Vec::new())),
@@ -670,9 +686,9 @@ impl Context {
             stack: None,
             loadable: false,
 
-            image: Arc::new(UnsafeCell::new(Vec::new())),
-            heap: Arc::new(UnsafeCell::new(Vec::new())),
-            mmap: Arc::new(UnsafeCell::new(Vec::new())),
+            image: Arc::new(UnsafeCell::new(ContextZone::new(CONTEXT_IMAGE_ADDR, CONTEXT_IMAGE_SIZE))),
+            heap: Arc::new(UnsafeCell::new(ContextZone::new(CONTEXT_HEAP_ADDR, CONTEXT_HEAP_SIZE))),
+            mmap: Arc::new(UnsafeCell::new(ContextZone::new(CONTEXT_MMAP_ADDR, CONTEXT_MMAP_SIZE))),
 
             cwd: Arc::new(UnsafeCell::new(String::new())),
             files: Arc::new(UnsafeCell::new(Vec::new())),
@@ -795,10 +811,16 @@ impl Context {
             }
         }
 
-        for mem in unsafe { (*self.memory.get()).iter() } {
-            if ptr >= mem.virtual_address && ptr < mem.virtual_address + mem.virtual_size {
-                return Ok(ptr - mem.virtual_address + mem.physical_address);
-            }
+        if let Some(address) = unsafe { (*self.image.get()).translate(ptr, len) } {
+            return Ok(address);
+        }
+
+        if let Some(address) = unsafe { (*self.heap.get()).translate(ptr, len) } {
+            return Ok(address);
+        }
+
+        if let Some(address) = unsafe { (*self.mmap.get()).translate(ptr, len) } {
+            return Ok(address);
         }
 
         Err(Error::new(EFAULT))
@@ -808,15 +830,15 @@ impl Context {
         if let Some(ref mut stack) = self.stack {
             stack.map();
         }
-        for entry in (*self.memory.get()).iter_mut() {
-            entry.map();
-        }
+        (*self.image.get()).map();
+        (*self.heap.get()).map();
+        (*self.mmap.get()).map();
     }
 
     pub unsafe fn unmap(&mut self) {
-        for entry in (*self.memory.get()).iter_mut() {
-            entry.unmap();
-        }
+        (*self.mmap.get()).unmap();
+        (*self.heap.get()).unmap();
+        (*self.image.get()).unmap();
         if let Some(ref mut stack) = self.stack {
             stack.unmap();
         }

--- a/kernel/arch/context.rs
+++ b/kernel/arch/context.rs
@@ -26,7 +26,7 @@ use system::error::{Error, Result, EBADF, EFAULT, ENOMEM, ESRCH};
 use sync::WaitMap;
 
 pub const CONTEXT_STACK_SIZE: usize = 1024 * 1024;
-pub const CONTEXT_STACK_ADDR: usize = 0xB0000000;
+pub const CONTEXT_STACK_ADDR: usize = 0x80000000;
 
 pub struct ContextManager {
     pub inner: Vec<Box<Context>>,

--- a/kernel/disk/ahci/hba.rs
+++ b/kernel/disk/ahci/hba.rs
@@ -126,7 +126,7 @@ impl HbaPort {
     }
 
     pub fn ata_dma(&mut self, block: u64, sectors: usize, mut buf: usize, write: bool) -> Result<usize> {
-        debugln!("AHCI {:X} DMA BLOCK: {:X} SECTORS: {} BUF: {:X} WRITE: {}", (self as *mut HbaPort) as usize, block, sectors, buf, write);
+        // debugln!("AHCI {:X} DMA BLOCK: {:X} SECTORS: {} BUF: {:X} WRITE: {}", (self as *mut HbaPort) as usize, block, sectors, buf, write);
 
         if buf >= 0x80000000 {
             buf -= 0x80000000;

--- a/kernel/disk/ahci/hba.rs
+++ b/kernel/disk/ahci/hba.rs
@@ -125,13 +125,8 @@ impl HbaPort {
         None
     }
 
-    pub fn ata_dma(&mut self,
-                   block: u64,
-                   sectors: usize,
-                   buf: usize,
-                   write: bool)
-                   -> Result<usize> {
-        // debugln!("AHCI {:X} DMA BLOCK: {:X} SECTORS: {} BUF: {:X} WRITE: {}", (self as *mut HbaPort) as usize, block, sectors, buf, write);
+    pub fn ata_dma(&mut self, block: u64, sectors: usize, buf: usize, write: bool) -> Result<usize> {
+        debugln!("AHCI {:X} DMA BLOCK: {:X} SECTORS: {} BUF: {:X} WRITE: {}", (self as *mut HbaPort) as usize, block, sectors, buf, write);
 
         // TODO: PRDTL for files larger than 4MB
         let entries = 1;

--- a/kernel/disk/ahci/hba.rs
+++ b/kernel/disk/ahci/hba.rs
@@ -125,8 +125,12 @@ impl HbaPort {
         None
     }
 
-    pub fn ata_dma(&mut self, block: u64, sectors: usize, buf: usize, write: bool) -> Result<usize> {
+    pub fn ata_dma(&mut self, block: u64, sectors: usize, mut buf: usize, write: bool) -> Result<usize> {
         debugln!("AHCI {:X} DMA BLOCK: {:X} SECTORS: {} BUF: {:X} WRITE: {}", (self as *mut HbaPort) as usize, block, sectors, buf, write);
+
+        if buf >= 0x80000000 {
+            buf -= 0x80000000;
+        }
 
         // TODO: PRDTL for files larger than 4MB
         let entries = 1;

--- a/kernel/disk/ide.rs
+++ b/kernel/disk/ide.rs
@@ -420,7 +420,7 @@ impl IdeDisk {
     }
 
     fn ata_pio(&mut self, block: u64, sectors: usize, buf: usize, write: bool) -> Result<usize> {
-        debugln!("IDE PIO BLOCK: {} SECTORS: {} BUF: {:X} WRITE: {}", block, sectors, buf, write);
+        // debugln!("IDE PIO BLOCK: {} SECTORS: {} BUF: {:X} WRITE: {}", block, sectors, buf, write);
 
         if buf > 0 && sectors > 0 {
             let mut sector: usize = 0;
@@ -533,7 +533,7 @@ impl IdeDisk {
     }
 
     fn ata_dma(&mut self, block: u64, sectors: usize, buf: usize, write: bool) -> Result<usize> {
-        debugln!("IDE DMA BLOCK: {} SECTORS: {} BUF: {:X} WRITE: {}", block, sectors, buf, write);
+        // debugln!("IDE DMA BLOCK: {} SECTORS: {} BUF: {:X} WRITE: {}", block, sectors, buf, write);
 
         if buf > 0 && sectors > 0 {
             let mut sector: usize = 0;

--- a/kernel/disk/ide.rs
+++ b/kernel/disk/ide.rs
@@ -418,7 +418,7 @@ impl IdeDisk {
     }
 
     fn ata_pio(&mut self, block: u64, sectors: usize, buf: usize, write: bool) -> Result<usize> {
-        // debugln!("IDE PIO BLOCK: {} SECTORS: {} BUF: {:X} WRITE: {}", block, sectors, buf, write);
+        debugln!("IDE PIO BLOCK: {} SECTORS: {} BUF: {:X} WRITE: {}", block, sectors, buf, write);
 
         if buf > 0 && sectors > 0 {
             let mut sector: usize = 0;
@@ -532,7 +532,7 @@ impl IdeDisk {
     }
 
     fn ata_dma(&mut self, block: u64, sectors: usize, buf: usize, write: bool) -> Result<usize> {
-        // debugln!("IDE DMA BLOCK: {} SECTORS: {} BUF: {:X} WRITE: {}", block, sectors, buf, write);
+        debugln!("IDE DMA BLOCK: {} SECTORS: {} BUF: {:X} WRITE: {}", block, sectors, buf, write);
 
         if buf > 0 && sectors > 0 {
             let mut sector: usize = 0;

--- a/kernel/disk/ide.rs
+++ b/kernel/disk/ide.rs
@@ -368,7 +368,10 @@ impl IdeDisk {
                           ((destination.read(103) as u64) << 48);
 
         if sectors == 0 {
+            debugln!(" 28-bit LBA");
             sectors = (destination.read(60) as u64) | ((destination.read(61) as u64) << 16);
+        } else {
+            debugln!(" 48-bit LBA");
         }
 
         debug!(" Size: {} MB", (sectors / 2048) as usize);
@@ -376,12 +379,11 @@ impl IdeDisk {
         true
     }
 
-    unsafe fn ata_pio_small(&mut self,
-                            block: u64,
-                            sectors: u16,
-                            buf: usize,
-                            write: bool)
-                            -> Result<usize> {
+    unsafe fn ata_pio_small(&mut self, block: u64, sectors: u16, mut buf: usize, write: bool) -> Result<usize> {
+        if buf >= 0x80000000 {
+            buf -= 0x80000000;
+        }
+
         if buf > 0 {
             self.ata(if write {
                 ATA_CMD_WRITE_PIO //_EXT
@@ -449,12 +451,11 @@ impl IdeDisk {
         }
     }
 
-    unsafe fn ata_dma_small(&mut self,
-                            block: u64,
-                            sectors: u16,
-                            buf: usize,
-                            write: bool)
-                            -> Result<usize> {
+    unsafe fn ata_dma_small(&mut self, block: u64, sectors: u16, mut buf: usize, write: bool) -> Result<usize> {
+        if buf >= 0x80000000 {
+            buf -= 0x80000000;
+        }
+
         if buf > 0 {
             self.buscmd.writef(CMD_ACT, false);
 

--- a/kernel/fs/scheme.rs
+++ b/kernel/fs/scheme.rs
@@ -99,8 +99,9 @@ impl Resource for SchemeResource {
             let virtual_size = (buf.len() + offset + 4095)/4096 * 4096;
             if let Some(scheme) = self.inner.upgrade() {
                 unsafe {
-                    virtual_address = (*scheme.context).next_mem();
-                    (*(*scheme.context).memory.get()).push(ContextMemory {
+                    let mmap = &mut *(*scheme.context).mmap.get();
+                    virtual_address = mmap.next_mem();
+                    mmap.memory.push(ContextMemory {
                         physical_address: physical_address - offset,
                         virtual_address: virtual_address,
                         virtual_size: virtual_size,
@@ -117,10 +118,11 @@ impl Resource for SchemeResource {
 
                 if let Some(scheme) = self.inner.upgrade() {
                     unsafe {
-                        if let Ok(mut mem) = (*scheme.context).get_mem_mut(virtual_address) {
+                        let mmap = &mut *(*scheme.context).mmap.get();
+                        if let Ok(mut mem) = mmap.get_mem_mut(virtual_address) {
                             mem.virtual_size = 0;
                         }
-                        (*scheme.context).clean_mem();
+                        mmap.clean_mem();
                     }
                 }
 
@@ -144,8 +146,9 @@ impl Resource for SchemeResource {
             let virtual_size = (buf.len() + offset + 4095)/4096 * 4096;
             if let Some(scheme) = self.inner.upgrade() {
                 unsafe {
-                    virtual_address = (*scheme.context).next_mem();
-                    (*(*scheme.context).memory.get()).push(ContextMemory {
+                    let mmap = &mut *(*scheme.context).mmap.get();
+                    virtual_address = mmap.next_mem();
+                    mmap.memory.push(ContextMemory {
                         physical_address: physical_address - offset,
                         virtual_address: virtual_address,
                         virtual_size: virtual_size,
@@ -162,10 +165,11 @@ impl Resource for SchemeResource {
 
                 if let Some(scheme) = self.inner.upgrade() {
                     unsafe {
-                        if let Ok(mut mem) = (*scheme.context).get_mem_mut(virtual_address) {
+                        let mmap = &mut *(*scheme.context).mmap.get();
+                        if let Ok(mut mem) = mmap.get_mem_mut(virtual_address) {
                             mem.virtual_size = 0;
                         }
-                        (*scheme.context).clean_mem();
+                        mmap.clean_mem();
                     }
                 }
 
@@ -189,12 +193,13 @@ impl Resource for SchemeResource {
             let virtual_size = (buf.len() + offset + 4095)/4096 * 4096;
             if let Some(scheme) = self.inner.upgrade() {
                 unsafe {
-                    virtual_address = (*scheme.context).next_mem();
-                    (*(*scheme.context).memory.get()).push(ContextMemory {
+                    let mmap = &mut *(*scheme.context).mmap.get();
+                    virtual_address = mmap.next_mem();
+                    mmap.memory.push(ContextMemory {
                         physical_address: physical_address - offset,
                         virtual_address: virtual_address,
                         virtual_size: virtual_size,
-                        writeable: true,
+                        writeable: false,
                         allocated: false,
                     });
                 }
@@ -207,10 +212,11 @@ impl Resource for SchemeResource {
 
                 if let Some(scheme) = self.inner.upgrade() {
                     unsafe {
-                        if let Ok(mut mem) = (*scheme.context).get_mem_mut(virtual_address) {
+                        let mmap = &mut *(*scheme.context).mmap.get();
+                        if let Ok(mut mem) = mmap.get_mem_mut(virtual_address) {
                             mem.virtual_size = 0;
                         }
-                        (*scheme.context).clean_mem();
+                        mmap.clean_mem();
                     }
                 }
 
@@ -381,13 +387,15 @@ impl KScheme for Scheme {
         }
 
         let mut virtual_address = 0;
+        let virtual_size = c_str.len();
         if let Some(scheme) = self.inner.upgrade() {
             unsafe {
-                virtual_address = (*scheme.context).next_mem();
-                (*(*scheme.context).memory.get()).push(ContextMemory {
+                let mmap = &mut *(*scheme.context).mmap.get();
+                virtual_address = mmap.next_mem();
+                mmap.memory.push(ContextMemory {
                     physical_address: physical_address,
                     virtual_address: virtual_address,
-                    virtual_size: c_str.len(),
+                    virtual_size: virtual_size,
                     writeable: false,
                     allocated: false,
                 });
@@ -399,10 +407,11 @@ impl KScheme for Scheme {
 
             if let Some(scheme) = self.inner.upgrade() {
                 unsafe {
-                    if let Ok(mut mem) = (*scheme.context).get_mem_mut(virtual_address) {
+                    let mmap = &mut *(*scheme.context).mmap.get();
+                    if let Ok(mut mem) = mmap.get_mem_mut(virtual_address) {
                         mem.virtual_size = 0;
                     }
-                    (*scheme.context).clean_mem();
+                    mmap.clean_mem();
                 }
             }
 
@@ -427,13 +436,15 @@ impl KScheme for Scheme {
         }
 
         let mut virtual_address = 0;
+        let virtual_size = c_str.len();
         if let Some(scheme) = self.inner.upgrade() {
             unsafe {
-                virtual_address = (*scheme.context).next_mem();
-                (*(*scheme.context).memory.get()).push(ContextMemory {
+                let mmap = &mut *(*scheme.context).mmap.get();
+                virtual_address = mmap.next_mem();
+                mmap.memory.push(ContextMemory {
                     physical_address: physical_address,
                     virtual_address: virtual_address,
-                    virtual_size: c_str.len(),
+                    virtual_size: virtual_size,
                     writeable: false,
                     allocated: false,
                 });
@@ -445,10 +456,11 @@ impl KScheme for Scheme {
 
             if let Some(scheme) = self.inner.upgrade() {
                 unsafe {
-                    if let Ok(mut mem) = (*scheme.context).get_mem_mut(virtual_address) {
+                    let mmap = &mut *(*scheme.context).mmap.get();
+                    if let Ok(mut mem) = mmap.get_mem_mut(virtual_address) {
                         mem.virtual_size = 0;
                     }
-                    (*scheme.context).clean_mem();
+                    mmap.clean_mem();
                 }
             }
 
@@ -467,13 +479,15 @@ impl KScheme for Scheme {
         }
 
         let mut virtual_address = 0;
+        let virtual_size = c_str.len();
         if let Some(scheme) = self.inner.upgrade() {
             unsafe {
-                virtual_address = (*scheme.context).next_mem();
-                (*(*scheme.context).memory.get()).push(ContextMemory {
+                let mmap = &mut *(*scheme.context).mmap.get();
+                virtual_address = mmap.next_mem();
+                mmap.memory.push(ContextMemory {
                     physical_address: physical_address,
                     virtual_address: virtual_address,
-                    virtual_size: c_str.len(),
+                    virtual_size: virtual_size,
                     writeable: false,
                     allocated: false,
                 });
@@ -485,10 +499,11 @@ impl KScheme for Scheme {
 
             if let Some(scheme) = self.inner.upgrade() {
                 unsafe {
-                    if let Ok(mut mem) = (*scheme.context).get_mem_mut(virtual_address) {
+                    let mmap = &mut *(*scheme.context).mmap.get();
+                    if let Ok(mut mem) = mmap.get_mem_mut(virtual_address) {
                         mem.virtual_size = 0;
                     }
-                    (*scheme.context).clean_mem();
+                    mmap.clean_mem();
                 }
             }
 
@@ -507,13 +522,15 @@ impl KScheme for Scheme {
         }
 
         let mut virtual_address = 0;
+        let virtual_size = c_str.len();
         if let Some(scheme) = self.inner.upgrade() {
             unsafe {
-                virtual_address = (*scheme.context).next_mem();
-                (*(*scheme.context).memory.get()).push(ContextMemory {
+                let mmap = &mut *(*scheme.context).mmap.get();
+                virtual_address = mmap.next_mem();
+                mmap.memory.push(ContextMemory {
                     physical_address: physical_address,
                     virtual_address: virtual_address,
-                    virtual_size: c_str.len(),
+                    virtual_size: virtual_size,
                     writeable: false,
                     allocated: false,
                 });
@@ -525,10 +542,11 @@ impl KScheme for Scheme {
 
             if let Some(scheme) = self.inner.upgrade() {
                 unsafe {
-                    if let Ok(mut mem) = (*scheme.context).get_mem_mut(virtual_address) {
+                    let mmap = &mut *(*scheme.context).mmap.get();
+                    if let Ok(mut mem) = mmap.get_mem_mut(virtual_address) {
                         mem.virtual_size = 0;
                     }
-                    (*scheme.context).clean_mem();
+                    mmap.clean_mem();
                 }
             }
 

--- a/kernel/fs/scheme.rs
+++ b/kernel/fs/scheme.rs
@@ -375,7 +375,10 @@ impl KScheme for Scheme {
     fn open(&mut self, url: Url, flags: usize) -> Result<Box<Resource>> {
         let c_str = url.to_string() + "\0";
 
-        let physical_address = c_str.as_ptr() as usize;
+        let mut physical_address = c_str.as_ptr() as usize;
+        if physical_address >= 0x80000000 {
+            physical_address -= 0x80000000;
+        }
 
         let mut virtual_address = 0;
         if let Some(scheme) = self.inner.upgrade() {
@@ -418,7 +421,10 @@ impl KScheme for Scheme {
     fn mkdir(&mut self, url: Url, flags: usize) -> Result<()> {
         let c_str = url.to_string() + "\0";
 
-        let physical_address = c_str.as_ptr() as usize;
+        let mut physical_address = c_str.as_ptr() as usize;
+        if physical_address >= 0x80000000 {
+            physical_address -= 0x80000000;
+        }
 
         let mut virtual_address = 0;
         if let Some(scheme) = self.inner.upgrade() {
@@ -455,7 +461,10 @@ impl KScheme for Scheme {
     fn rmdir(&mut self, url: Url) -> Result<()> {
         let c_str = url.to_string() + "\0";
 
-        let physical_address = c_str.as_ptr() as usize;
+        let mut physical_address = c_str.as_ptr() as usize;
+        if physical_address >= 0x80000000 {
+            physical_address -= 0x80000000;
+        }
 
         let mut virtual_address = 0;
         if let Some(scheme) = self.inner.upgrade() {
@@ -492,7 +501,10 @@ impl KScheme for Scheme {
     fn unlink(&mut self, url: Url) -> Result<()> {
         let c_str = url.to_string() + "\0";
 
-        let physical_address = c_str.as_ptr() as usize;
+        let mut physical_address = c_str.as_ptr() as usize;
+        if physical_address >= 0x80000000 {
+            physical_address -= 0x80000000;
+        }
 
         let mut virtual_address = 0;
         if let Some(scheme) = self.inner.upgrade() {

--- a/kernel/main.rs
+++ b/kernel/main.rs
@@ -287,10 +287,10 @@ unsafe fn init(tss_data: usize) {
         let start_ptr = 0;
         let end_ptr = 0x1000;
 
-        if start_ptr as usize <= end_ptr {
-            let size = end_ptr - start_ptr as usize;
+        if start_ptr <= end_ptr {
+            let size = end_ptr - start_ptr;
             for page in 0..(size + 4095)/4096 {
-                Page::new(start_ptr as usize + page * 4096).unmap();
+                Page::new(start_ptr + page * 4096).unmap();
             }
         }
     }
@@ -299,11 +299,11 @@ unsafe fn init(tss_data: usize) {
     {
         let start_ptr = & __text_start as *const u8 as usize;
         let end_ptr = & __text_end as *const u8 as usize;
-        if start_ptr as usize <= end_ptr {
-            let size = end_ptr - start_ptr as usize;
+        if start_ptr <= end_ptr {
+            let size = end_ptr - start_ptr;
             for page in 0..(size + 4095)/4096 {
-                Page::new(start_ptr as usize + page * 4096).
-                    map_kernel_read(start_ptr as usize + page * 4096);
+                Page::new(start_ptr + page * 4096).
+                    map_kernel_read(start_ptr + page * 4096);
             }
         }
     }
@@ -317,6 +317,19 @@ unsafe fn init(tss_data: usize) {
             for page in 0..(size + 4095)/4096 {
                 Page::new(start_ptr + page * 4096).
                     map_kernel_read(start_ptr + page * 4096);
+            }
+        }
+    }
+
+    // Unmap logical/high mem
+    {
+        let start_ptr = 0x80000000;
+        let end_ptr = 0xE0000000;
+
+        if start_ptr <= end_ptr {
+            let size = end_ptr - start_ptr;
+            for page in 0..(size + 4095)/4096 {
+                Page::new(start_ptr + page * 4096).unmap();
             }
         }
     }

--- a/kernel/schemes/context.rs
+++ b/kernel/schemes/context.rs
@@ -36,11 +36,9 @@ impl KScheme for ContextScheme {
                 if let Some(ref stack) = context.stack {
                     memory += stack.virtual_size;
                 }
-                unsafe {
-                    for context_memory in (*context.memory.get()).iter() {
-                        memory += context_memory.virtual_size;
-                    }
-                }
+                memory += unsafe { (*context.image.get()).size() };
+                memory += unsafe { (*context.heap.get()).size() };
+                memory += unsafe { (*context.mmap.get()).size() };
 
                 let memory_string = if memory >= 1024 * 1024 * 1024 {
                     format!("{} GB", memory / 1024 / 1024 / 1024)

--- a/kernel/syscall/execute.rs
+++ b/kernel/syscall/execute.rs
@@ -1,6 +1,7 @@
 use alloc::arc::Arc;
 
-use arch::context::{CONTEXT_STACK_SIZE, CONTEXT_STACK_ADDR, context_switch, context_userspace, Context, ContextMemory};
+use arch::context::{CONTEXT_IMAGE_ADDR, CONTEXT_IMAGE_SIZE, CONTEXT_STACK_SIZE, CONTEXT_STACK_ADDR,
+                    context_switch, context_userspace, Context, ContextMemory, ContextZone};
 use arch::elf::Elf;
 use arch::memory;
 use arch::regs::Regs;
@@ -36,13 +37,13 @@ pub fn execute_thread(context_ptr: *mut Context, entry: usize, mut args: Vec<Str
                 physical_address -= 0x80000000;
             }
 
-            let virtual_address = context.next_mem();
+            let virtual_address = unsafe { (*context.image.get()).next_mem() };
             let virtual_size = arg.len();
 
             mem::forget(arg);
 
             unsafe {
-                (*context.memory.get()).push(ContextMemory {
+                (*context.image.get()).memory.push(ContextMemory {
                     physical_address: physical_address,
                     virtual_address: virtual_address,
                     virtual_size: virtual_size,
@@ -55,24 +56,6 @@ pub fn execute_thread(context_ptr: *mut Context, entry: usize, mut args: Vec<Str
             argc += 1;
         }
         context_args.push(argc);
-
-        //TODO: No default heap, fix brk
-        {
-            let virtual_address = context.next_mem();
-            let virtual_size = 4096;
-            let physical_address = unsafe { memory::alloc_aligned(virtual_size, 4096) };
-            if physical_address > 0 {
-                unsafe {
-                    (*context.memory.get()).push(ContextMemory {
-                        physical_address: physical_address,
-                        virtual_address: virtual_address,
-                        virtual_size: virtual_size,
-                        writeable: true,
-                        allocated: true
-                    });
-                }
-            }
-        }
 
         context.iopl = 0;
 
@@ -209,7 +192,9 @@ pub fn execute(mut args: Vec<String>) -> Result<usize> {
                     context.cwd = Arc::new(UnsafeCell::new(unsafe { (*context.cwd.get()).clone() }));
 
                     unsafe { context.unmap() };
-                    context.memory = Arc::new(UnsafeCell::new(memory));
+                    let mut image = ContextZone::new(CONTEXT_IMAGE_ADDR, CONTEXT_IMAGE_SIZE);
+                    image.memory = memory;
+                    context.image = Arc::new(UnsafeCell::new(image));
                     unsafe { context.map() };
 
                     execute_thread(context.deref_mut(), entry, args);

--- a/kernel/syscall/execute.rs
+++ b/kernel/syscall/execute.rs
@@ -31,7 +31,11 @@ pub fn execute_thread(context_ptr: *mut Context, entry: usize, mut args: Vec<Str
                 arg.push('\0');
             }
 
-            let physical_address = arg.as_ptr() as usize;
+            let mut physical_address = arg.as_ptr() as usize;
+            if physical_address >= 0x80000000 {
+                physical_address -= 0x80000000;
+            }
+
             let virtual_address = context.next_mem();
             let virtual_size = arg.len();
 


### PR DESCRIPTION
**Problem**: 

The allocator does not map memory correctly, causing allocations to fail when it hits an address that is not identity mapped.

**Solution**:

Make the allocator remap memory when necessary, refactor the kernel to allow for the use of "logical" addresses

**Changes introduced by this pull request**:

- Logical offsets for kernel allocations, map virtual memory when allocations happen
- Undo logical offset for use in drivers, when detected
- Do not identity map all memory
- Add three context "zones" for allocating memory to contexts: image, heap, and mmap
- The image zone is for the program's image (text, data, bss, loaded by exec)
- The heap zone is for the program's dynamic allocations (done by brk)
- The mmap zone is for the program's shared memory (while handling scheme operations as a server).
- The mmap zone will also be reused for mapping MMIO

**Drawbacks**:

This is by no means done in a safe, reliable, consistent, clean, idiomatic, or efficient way, and significant improvements can be made to the code quality and performance.

**TODOs**:

- Code cleanup
- Improvements for safety
- Improvements for performance
- Testing

**Fixes**:
Fixes #536 
Fixes #549 
Fixes #590
Fixes #591
Fixes #592