### PR TITLE
Fix the build

### DIFF
--- a/libstd/src/num/f32.rs
+++ b/libstd/src/num/f32.rs
@@ -1018,12 +1018,13 @@ impl f32 {
     ///
     /// assert!(abs_difference <= f32::EPSILON);
     /// ```
-        #[inline]
+    #[inline]
     pub fn asinh(self) -> f32 {
-        match self {
-            NEG_INFINITY => NEG_INFINITY,
-            x => (x + ((x * x) + 1.0).sqrt()).ln(),
+        if self == NEG_INFINITY {
+            return NEG_INFINITY;
         }
+
+        (self + ((self * self) + 1.0).sqrt()).ln()
     }
 
     /// Inverse hyperbolic cosine function.

--- a/libstd/src/num/f64.rs
+++ b/libstd/src/num/f64.rs
@@ -952,10 +952,11 @@ impl f64 {
     /// ```
         #[inline]
     pub fn asinh(self) -> f64 {
-        match self {
-            NEG_INFINITY => NEG_INFINITY,
-            x => (x + ((x * x) + 1.0).sqrt()).ln(),
+        if self == NEG_INFINITY {
+            return NEG_INFINITY;
         }
+
+        (self + ((self * self) + 1.0).sqrt()).ln()
     }
 
     /// Inverse hyperbolic cosine function.


### PR DESCRIPTION
**Problem**: The build fails due to a newly introduced lint.

**Solution**: Work around this, by avoiding the use of `match`.

**Changes introduced by this pull request**:

- Convert the match into an if.

**State**: Ready.

**Blocking/related**: fixes #596.

**Other**: Introduced by https://github.com/rust-lang/rfcs/pull/1445
