### PR TITLE
Add environment variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -197,8 +197,7 @@ extrautils: \
 	filesystem/bin/grep \
 	filesystem/bin/less \
 	filesystem/bin/mtxt \
-	filesystem/bin/rem \
-	filesystem/bin/envtest
+	filesystem/bin/rem
 
 filesystem/bin/%: crates/games/src/%/main.rs crates/games/src/%/*.rs $(BUILD)/libextra.rlib $(BUILD)/libtermion.rlib
 	mkdir -p filesystem/bin

--- a/Makefile
+++ b/Makefile
@@ -197,7 +197,8 @@ extrautils: \
 	filesystem/bin/grep \
 	filesystem/bin/less \
 	filesystem/bin/mtxt \
-	filesystem/bin/rem
+	filesystem/bin/rem \
+	filesystem/bin/envtest
 
 filesystem/bin/%: crates/games/src/%/main.rs crates/games/src/%/*.rs $(BUILD)/libextra.rlib $(BUILD)/libtermion.rlib
 	mkdir -p filesystem/bin

--- a/kernel/arch/context.rs
+++ b/kernel/arch/context.rs
@@ -841,7 +841,7 @@ impl Context {
         Err(Error::new(EFAULT))
     }
 
-    /// Gets an environment variable. Returns `None` if the variable is not defined
+    /// Gets an environment variable. Returns `Err` if the variable is not defined
     pub fn get_env_var(&self, var_name: &str) -> Result<String> {
         for variable in unsafe { (*self.env_vars.get()).iter() } {
             if &variable.name == var_name {
@@ -851,7 +851,7 @@ impl Context {
         Err(Error::new(ENOENT))
     }
 
-    /// Sets an environment variable. Returns `None` if the variable name contains the `=`
+    /// Sets an environment variable. Returns `Err` if the variable name contains the `=`
     /// character
     pub fn set_env_var(&mut self, name: &str, value: &str) -> Result<()> {
         if name.contains('=') {
@@ -868,6 +868,7 @@ impl Context {
         Ok(())
     }
 
+    /// Returns a list of the environment variables
     pub fn list_env_vars(&self) -> Result<Vec<(String, String)>> {
         let mut vars_buf = Vec::new();
         for ref variable in unsafe { (*self.env_vars.get()).iter() } {

--- a/kernel/main.rs
+++ b/kernel/main.rs
@@ -63,6 +63,7 @@ use graphics::display;
 use schemes::context::*;
 use schemes::debug::*;
 use schemes::display::*;
+use schemes::env::*;
 use schemes::initfs::*;
 use schemes::interrupt::*;
 use schemes::memory::*;
@@ -360,6 +361,7 @@ unsafe fn init(tss_data: usize) {
             env.schemes.lock().push(InitFsScheme::new());
             env.schemes.lock().push(box ContextScheme);
             env.schemes.lock().push(box DisplayScheme);
+            env.schemes.lock().push(box EnvScheme);
             env.schemes.lock().push(box InterruptScheme);
             env.schemes.lock().push(box MemoryScheme);
             env.schemes.lock().push(box TestScheme);

--- a/kernel/schemes/env.rs
+++ b/kernel/schemes/env.rs
@@ -1,0 +1,75 @@
+use fs::{KScheme, Resource, Url};
+use fs::resource::ResourceSeek;
+use collections::string::String;
+use alloc::boxed::Box;
+use system::error::{Error, Result, EINVAL};
+use core::cmp::min;
+
+pub struct EnvScheme;
+
+impl KScheme for EnvScheme {
+    fn scheme(&self) -> &str {
+        "env"
+    }
+
+    fn open(&mut self, url: Url, _: usize) -> Result<Box<Resource>> {
+        let name = url.reference();
+        if name.contains('=') { return Err(Error::new(EINVAL)) }
+        Ok(box EnvResource {
+            name: String::from(name),
+            pos: 0
+        })
+    }
+}
+
+pub struct EnvResource {
+    name: String,
+    pos: usize
+}
+
+impl Resource for EnvResource {
+    fn dup(&self) -> Result<Box<Resource>> {
+        Ok(box EnvResource { name: self.name.clone(), pos: 0 })
+    }
+
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
+        let contexts = ::env().contexts.lock();
+        let current = try!(contexts.current());
+        let value = try!(current.get_env_var(&self.name));
+        let mut i = 0;
+        while i < buf.len() && self.pos < value.bytes().count() {
+            match value.bytes().nth(self.pos) {
+                Some(c) => buf[i] = c as u8,
+                None => ()
+            }
+            i += 1;
+            self.pos += 1;
+        }
+        Ok(i)
+    }
+
+    fn write(&mut self, buf: &[u8]) -> Result<usize> {
+        let mut contexts = ::env().contexts.lock();
+        let current = try!(contexts.current_mut());
+        let value = String::from_utf8_lossy(buf).into_owned();
+        if value.contains('�') {
+            return Err(Error::new(EINVAL));
+        }
+        try!(current.set_env_var(&self.name, &value));
+        Ok(min(value.as_bytes().len(), buf.len()))
+    }
+
+    fn seek(&mut self, pos: ResourceSeek) -> Result<usize> {
+        match pos {
+            ResourceSeek::Start(offset) => self.pos = offset,
+            ResourceSeek::Current(offset) => self.pos = (self.pos as isize + offset) as usize,
+            ResourceSeek::End(offset) => {
+                let contexts = ::env().contexts.lock();
+                let current = try!(contexts.current());
+                let value = try!(current.get_env_var(&self.name));
+                self.pos = (value.bytes().count() as isize + offset) as usize;
+            }
+        }
+        Ok(self.pos)
+    }
+}

--- a/kernel/schemes/env.rs
+++ b/kernel/schemes/env.rs
@@ -15,21 +15,77 @@ impl KScheme for EnvScheme {
     fn open(&mut self, url: Url, _: usize) -> Result<Box<Resource>> {
         let name = url.reference();
         if name.contains('=') { return Err(Error::new(EINVAL)) }
-        Ok(box EnvResource {
-            name: String::from(name),
-            pos: 0
-        })
+        if name == "" || name == "/" {
+            Ok(box EnvListResource {
+                pos: 0
+            })
+        } else {
+            Ok(box EnvVariableResource {
+                name: String::from(name),
+                pos: 0
+            })
+        }
     }
 }
 
-pub struct EnvResource {
+pub struct EnvListResource {
+    pos: usize
+}
+
+impl EnvListResource {
+    fn get_list_str(&self) -> Result<String> {
+        let contexts = ::env().contexts.lock();
+        let current = try!(contexts.current());
+        let values = try!(current.list_env_vars());
+        let mut string = String::new();
+        for &(ref name, ref value) in values.iter() {
+            string = string + name + "=" + value + "\n";
+        }
+        string.pop();
+        Ok(string)
+    }
+}
+
+impl Resource for EnvListResource {
+    fn dup(&self) -> Result<Box<Resource>> {
+        Ok(box EnvListResource { pos: 0 })
+    }
+
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
+        let mut i = 0;
+        let string = try!(self.get_list_str());
+        while i < buf.len() && self.pos < string.bytes().count() {
+            match string.bytes().nth(self.pos) {
+                Some(c) => buf[i] = c,
+                None => ()
+            }
+            i += 1;
+            self.pos += 1;
+        }
+        Ok(i)
+    }
+
+    fn seek(&mut self, pos: ResourceSeek) -> Result<usize> {
+        match pos {
+            ResourceSeek::Start(offset) => self.pos = offset,
+            ResourceSeek::Current(offset) => self.pos = (self.pos as isize + offset) as usize,
+            ResourceSeek::End(offset) => {
+                let string = try!(self.get_list_str());
+                self.pos = (string.bytes().count() as isize + offset) as usize;
+            }
+        }
+        Ok(self.pos)
+    }
+}
+
+pub struct EnvVariableResource {
     name: String,
     pos: usize
 }
 
-impl Resource for EnvResource {
+impl Resource for EnvVariableResource {
     fn dup(&self) -> Result<Box<Resource>> {
-        Ok(box EnvResource { name: self.name.clone(), pos: 0 })
+        Ok(box EnvVariableResource { name: self.name.clone(), pos: 0 })
     }
 
     fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
@@ -39,7 +95,7 @@ impl Resource for EnvResource {
         let mut i = 0;
         while i < buf.len() && self.pos < value.bytes().count() {
             match value.bytes().nth(self.pos) {
-                Some(c) => buf[i] = c as u8,
+                Some(c) => buf[i] = c,
                 None => ()
             }
             i += 1;

--- a/kernel/schemes/mod.rs
+++ b/kernel/schemes/mod.rs
@@ -4,6 +4,8 @@ pub mod context;
 pub mod debug;
 /// Display Scheme
 pub mod display;
+/// Environment variables scheme
+pub mod env;
 /// File scheme
 pub mod file;
 /// Init Filesystem

--- a/libstd/src/env.rs
+++ b/libstd/src/env.rs
@@ -4,7 +4,7 @@ use alloc::boxed::Box;
 
 use core_collections::borrow::ToOwned;
 
-use ffi::OsString;
+use ffi::{OsString, OsStr};
 use fs::File;
 use path::{Path, PathBuf};
 use string::{String, ToString};
@@ -14,7 +14,7 @@ use vec::Vec;
 use system::error::ENOENT;
 use system::syscall::sys_chdir;
 
-use io::{Error, Result};
+use io::{Error, Result, Read, Write};
 
 static mut _args: *mut Vec<&'static str> = 0 as *mut Vec<&'static str>;
 
@@ -132,20 +132,62 @@ pub enum VarError {
     NotUnicode(OsString),
 }
 
-// TODO: Fully implement `env::var()`
-pub fn var(_key: &str) -> ::core::result::Result<String, VarError> {
-    Err(VarError::NotPresent)
+pub fn var<K: AsRef<OsStr>>(key: K) -> ::core::result::Result<String, VarError> {
+    if let Some(key_str) = key.as_ref().to_str() {
+        let mut file = try!(File::open(&("env:".to_owned() + key_str)).or(Err(VarError::NotPresent)));
+        let mut string = String::new();
+        try!(file.read_to_string(&mut string).or(Err(VarError::NotPresent)));
+        Ok(string)
+    } else {
+        Err(VarError::NotUnicode(key.as_ref().to_owned()))
+    }
 }
 
-pub struct Vars;
-
-impl Iterator for Vars {
-    type Item = (String, String);
-    fn next(&mut self) -> Option<Self::Item> {
+pub fn var_os<K: AsRef<OsStr>>(key: K) -> Option<OsString> {
+    if let Ok(value) = var(key) {
+        Some((value.as_ref() as &OsStr).to_owned())
+    } else {
         None
     }
 }
 
+pub fn set_var<K: AsRef<OsStr>, V: AsRef<OsStr>>(key: K, value: V) {
+    if let (Some(key_str), Some(value_str)) = (key.as_ref().to_str(), value.as_ref().to_str()) {
+        if let Ok(mut file) = File::open(&("env:".to_owned() + key_str)) {
+            let _ = file.write_all(value_str.as_bytes());
+        }
+    }
+}
+
+pub struct Vars {
+    vars: Vec<(String, String)>,
+    pos: usize
+}
+
+impl Iterator for Vars {
+    type Item = (String, String);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let variable = self.vars.get(self.pos);
+        self.pos += 1;
+        variable.cloned()
+    }
+}
+
 pub fn vars() -> Vars {
-    Vars
+    let mut variables: Vec<(String, String)> = Vec::new();
+    if let Ok(mut file) = File::open("env:") {
+        let mut string = String::new();
+        if file.read_to_string(&mut string).is_ok() {
+            for line in string.lines() {
+                if let Some(equal_sign) = line.chars().position(|c| c == '=') {
+                    let name = line.chars().take(equal_sign).collect::<String>();
+                    let value = line.chars().skip(equal_sign+1).collect::<String>();
+                    variables.push((name, value));
+                }
+            }
+            return Vars { vars: variables, pos: 0 };
+        }
+    }
+    Vars { vars: Vec::new(), pos: 0 }
 }

--- a/libstd/src/env.rs
+++ b/libstd/src/env.rs
@@ -132,6 +132,8 @@ pub enum VarError {
     NotUnicode(OsString),
 }
 
+/// Returns the environment variable `key` from the current process. If `key` is not valid Unicode
+/// or if the variable is not present then `Err` is returned
 pub fn var<K: AsRef<OsStr>>(key: K) -> ::core::result::Result<String, VarError> {
     if let Some(key_str) = key.as_ref().to_str() {
         let mut file = try!(File::open(&("env:".to_owned() + key_str)).or(Err(VarError::NotPresent)));
@@ -151,6 +153,7 @@ pub fn var_os<K: AsRef<OsStr>>(key: K) -> Option<OsString> {
     }
 }
 
+/// Sets the environment variable `key` to the value `value` for the current process
 pub fn set_var<K: AsRef<OsStr>, V: AsRef<OsStr>>(key: K, value: V) {
     if let (Some(key_str), Some(value_str)) = (key.as_ref().to_str(), value.as_ref().to_str()) {
         if let Ok(mut file) = File::open(&("env:".to_owned() + key_str)) {
@@ -174,6 +177,7 @@ impl Iterator for Vars {
     }
 }
 
+/// Returns an iterator over the environment variables of the current process
 pub fn vars() -> Vars {
     let mut variables: Vec<(String, String)> = Vec::new();
     if let Ok(mut file) = File::open("env:") {


### PR DESCRIPTION
**Problem**: Redox doesn't have environment variables. Each process should have its own set of environment variables, that are copied to the child when the process forks.

**Changes introduced by this pull request**:

- Add the `env_vars` field to the  `Context` struct
- Add the `env` scheme to access environment variables from userspace
- Add the `env::var`, `env::set_var` and `env::vars` functions to `libstd`

**TODOs**:
- Add a way to remove environment variables (I'm working on it)
- Maybe add the `export` command to extrautils.
- Set the `HOME`, `PWD`, etc. variables on login

**State**: Ready