### PR TITLE
Introduce a new Redox-specific syscall, SYS_SUPERVISE.

### DIFF
--- a/crates/system/scheme.rs
+++ b/crates/system/scheme.rs
@@ -1,4 +1,3 @@
-
 use core::ops::{Deref, DerefMut};
 use core::{mem, slice};
 

--- a/crates/system/syscall/redox.rs
+++ b/crates/system/syscall/redox.rs
@@ -1,8 +1,40 @@
-use syscall::arch::syscall2;
+use syscall::arch::{syscall2, syscall1};
 use error::Result;
 
 pub const SYS_DEBUG: usize = 0;
+pub const SYS_SUPERVISE: usize = 1638; // loominatzi confirmed
 
 pub fn sys_debug(buf: &[u8]) -> Result<usize> {
     unsafe { syscall2(SYS_DEBUG, buf.as_ptr() as usize, buf.len()) }
+}
+
+/// <!-- @MANSTART{supervise} -->
+/// Supervise a given child process' system calls.
+///
+/// SUPERVISE allows a process to run another process in a restricted, traced, and supervised
+/// environment, which is useful for various purposes, such as emulation, virtualisation, tracing,
+/// logging, and debugging.
+///
+/// SUPERVISE takes a PID specifing the process to be supervised. This PID must be a child process
+/// of the invoker. If not, EACCES will be returned.
+///
+/// The process identified by the given PID will be restricted in such a way, that every syscall
+/// made will mark the process as blocked and store the syscall until it is handled by the parrent.
+///
+/// The return value (if successful) is a file descriptor, from which syscalls can be read and written:
+/// the syscalls are read in `Packet` sized packages, containing the respective blocking syscall. If
+/// no syscall is blocking (or the last blocking syscall have been handled), 0 bytes will be read to
+/// the buffer.
+///
+/// Writing pointer sized integers to this file handle will set the EAX register of the particular
+/// process, after which the process is unblocked and the syscall buffer is emptied. The behavior of
+/// writing packages of unexpected size is unspecified.
+///
+/// Note that a process blocked by a syscall will have its potential sleep cleared (i.e., it will
+/// not wake up after the sleep is finished).
+///
+/// Passing a non-existent PID results in ESRCH.
+/// <!-- @MANEND -->
+pub fn sys_supervise(pid: usize) -> Result<usize> {
+    unsafe { syscall1(SYS_SUPERVISE, pid) }
 }

--- a/crates/system/syscall/redox.rs
+++ b/crates/system/syscall/redox.rs
@@ -18,6 +18,9 @@ pub fn sys_debug(buf: &[u8]) -> Result<usize> {
 /// SUPERVISE takes a PID specifing the process to be supervised. This PID must be a child process
 /// of the invoker. If not, EACCES will be returned.
 ///
+/// A process can only have one supervisor at a time. If SUPERVISE is called on a process, which
+/// already have a supervisor EPERM will be returned.
+///
 /// The process identified by the given PID will be restricted in such a way, that every syscall
 /// made will mark the process as blocked and store the syscall until it is handled by the parrent.
 ///
@@ -34,6 +37,8 @@ pub fn sys_debug(buf: &[u8]) -> Result<usize> {
 /// not wake up after the sleep is finished).
 ///
 /// Passing a non-existent PID results in ESRCH.
+///
+/// A process being supervised is referred to as 'jailed' or 'supervised'.
 /// <!-- @MANEND -->
 pub fn sys_supervise(pid: usize) -> Result<usize> {
     unsafe { syscall1(SYS_SUPERVISE, pid) }

--- a/crates/system/syscall/unix.rs
+++ b/crates/system/syscall/unix.rs
@@ -8,6 +8,15 @@ pub const SYS_CLONE: usize = 120;
     pub const CLONE_FS: usize = 0x200;
     pub const CLONE_FILES: usize = 0x400;
     pub const CLONE_VFORK: usize = 0x4000;
+    /// Mark this clone as supervised.
+    ///
+    /// This means that the process can run in supervised mode, even not being connected to
+    /// a supervisor yet. In other words, the parent can later on supervise the process and handle
+    /// the potential blocking syscall.
+    ///
+    /// This is an important security measure, since otherwise the process would be able to fork it
+    /// self right after starting, making supervising it impossible.
+    pub const CLONE_SUPERVISE: usize = 0x400000;
 pub const SYS_CLOSE: usize = 6;
 pub const SYS_CLOCK_GETTIME: usize = 265;
     pub const CLOCK_REALTIME: usize = 1;

--- a/kernel/arch/context.rs
+++ b/kernel/arch/context.rs
@@ -72,19 +72,31 @@ impl ContextManager {
     }
 
     pub fn get(&self, i: usize) -> Result<&Box<Context>> {
-        if self.enabled {
-            self.inner.get(i).ok_or(Error::new(ESRCH))
-        } else{
-            Err(Error::new(ESRCH))
-        }
+        self.inner.get(i).ok_or(Error::new(ESRCH))
     }
 
     pub fn get_mut(&mut self, i: usize) -> Result<&mut Box<Context>> {
-        if self.enabled {
-            self.inner.get_mut(i).ok_or(Error::new(ESRCH))
-        } else{
-            Err(Error::new(ESRCH))
+        self.inner.get_mut(i).ok_or(Error::new(ESRCH))
+    }
+
+    /// Find a resource with a given PID.
+    pub fn find(&self, pid: usize) -> Result<&Box<Context>> {
+        for context in self.inner.iter() {
+            if context.pid == pid {
+                return Ok(context);
+            }
         }
+        Err(Error::new(ESRCH))
+    }
+
+    /// Find a resource with a given PID, and yield a mutable reference to it.
+    pub fn find_mut(&mut self, pid: usize) -> Result<&mut Box<Context>> {
+        for mut context in self.inner.iter_mut() {
+            if context.pid == pid {
+                return Ok(context);
+            }
+        }
+        Err(Error::new(ESRCH))
     }
 
     pub fn len(&self) -> usize {

--- a/kernel/arch/context.rs
+++ b/kernel/arch/context.rs
@@ -19,7 +19,7 @@ use core::ops::DerefMut;
 
 use fs::Resource;
 
-use syscall::{do_sys_exit, CLONE_FILES, CLONE_FS, CLONE_VM, CLONE_VFORK};
+use syscall::{do_sys_exit, CLONE_FILES, CLONE_FS, CLONE_VM, CLONE_VFORK, CLONE_SUPERVISE};
 
 use system::error::{Error, Result, EBADF, EFAULT, ENOMEM, ESRCH, ENOENT, EINVAL};
 
@@ -55,8 +55,7 @@ impl ContextManager {
     }
 
     pub fn current(&self) -> Result<&Box<Context>> {
-        let i = self.i;
-        self.get(i)
+        self.get(self.i)
     }
 
     pub fn current_mut(&mut self) -> Result<&mut Box<Context>> {
@@ -232,6 +231,9 @@ pub unsafe fn context_clone(regs: &Regs) -> Result<usize> {
                     None
                 },
                 wake: None,
+
+                supervised: flags & CLONE_SUPERVISE == CLONE_SUPERVISE,
+                blocked_syscall: false,
 
                 kernel_stack: kernel_stack,
                 regs: kernel_regs,
@@ -556,7 +558,7 @@ pub struct EnvironmentVariable {
 
 pub struct Context {
     // These members are used for control purposes by the scheduler {
-    // The PID of the context
+    /// The PID of the context
     pub pid: usize,
     /// The PID of the parent
     pub ppid: usize,
@@ -577,6 +579,16 @@ pub struct Context {
     /// When to wake up
     pub wake: Option<Duration>,
     // }
+
+    /// Is this process supervised?
+    ///
+    /// i.e., will the syscalls made by this process block the process until handled by
+    /// a supervisor?
+    pub supervised: bool,
+    /// Is this process currently blocked by a syscall?
+    ///
+    /// This means that the process is waiting for the superviser to handle the syscall.
+    pub blocked_syscall: bool,
 
     // These members control the stack and registers and are unique to each context {
     // The kernel stack
@@ -656,6 +668,9 @@ impl Context {
             vfork: None,
             wake: None,
 
+            supervised: false,
+            blocked_syscall: false,
+
             kernel_stack: 0,
             regs: Regs::default(),
             fx: fx,
@@ -694,6 +709,9 @@ impl Context {
             vfork: None,
             wake: None,
 
+            supervised: false,
+            blocked_syscall: false,
+
             kernel_stack: kernel_stack,
             regs: regs,
             fx: fx,
@@ -729,7 +747,7 @@ impl Context {
 
             let mut context_box_args: Vec<usize> = Vec::new();
             context_box_args.push(box_fn_ptr as usize);
-            context_box_args.push(0); //Return address, 0 catches bad code
+            context_box_args.push(0); // Return address, 0 catches bad code
 
             let context = Context::new(name, context_box as usize, &context_box_args);
 

--- a/kernel/arch/regs.rs
+++ b/kernel/arch/regs.rs
@@ -1,5 +1,7 @@
 pub use self::arch::*;
 
+use system::scheme::Packet;
+
 #[cfg(target_arch = "x86")]
 #[path="x86/regs.rs"]
 mod arch;
@@ -7,3 +9,15 @@ mod arch;
 #[cfg(target_arch = "x86_64")]
 #[path="x86_64/regs.rs"]
 mod arch;
+
+impl Into<Packet> for Regs {
+    fn into(self) -> Packet {
+        Packet {
+            id: 0, // TODO
+            a: self.ax,
+            b: self.bx,
+            c: self.cx,
+            d: self.dx,
+        }
+    }
+}

--- a/kernel/fs/mod.rs
+++ b/kernel/fs/mod.rs
@@ -5,6 +5,7 @@ pub use self::resource::{Resource, ResourceSeek};
 pub use self::scheme::Scheme;
 pub use self::url::{Url, OwnedUrl};
 pub use self::vec_resource::VecResource;
+pub use self::supervisor_resource::SupervisorResource;
 
 /// Kernel schemes
 pub mod kscheme;
@@ -16,3 +17,5 @@ pub mod scheme;
 pub mod url;
 /// Default resource
 pub mod vec_resource;
+/// Supervisor resource.
+pub mod supervisor_resource;

--- a/kernel/fs/supervisor_resource.rs
+++ b/kernel/fs/supervisor_resource.rs
@@ -1,0 +1,59 @@
+use core::{cmp, mem};
+use super::Resource;
+use system::error::Result;
+use system::scheme::Packet;
+
+/// A supervisor resource.
+///
+/// Reading from it will simply read the relevant registers to the buffer (see `Packet`).
+///
+/// Writing will simply left shift EAX by one byte, and then OR it with the byte from the buffer,
+/// effectively writing the buffer to the EAX register (truncating the additional bytes).
+pub struct SupervisorResource {
+    pid: usize,
+}
+
+impl SupervisorResource {
+    /// Create a new supervisor resource, supervising some PID.
+    pub fn new(pid: usize) -> SupervisorResource {
+        SupervisorResource {
+            pid: pid,
+        }
+    }
+}
+
+impl Resource for SupervisorResource {
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
+        let mut contexts = ::env().contexts.lock();
+        let ctx = try!(contexts.get_mut(self.pid));
+        if !ctx.blocked_syscall {
+            return Ok(0);
+        }
+
+        let call: Packet = ctx.regs.into();
+
+        for (&a, b) in call.iter().zip(buf.iter_mut()) {
+            *b = a;
+        }
+
+        ctx.blocked_syscall = false;
+
+        Ok(cmp::min(buf.len(), call.len()))
+    }
+
+    fn write(&mut self, buf: &[u8]) -> Result<usize> {
+        let mut contexts = ::env().contexts.lock();
+        let ctx = try!(contexts.get_mut(self.pid));
+
+        for &i in buf.iter().take(mem::size_of::<usize>()) {
+            ctx.regs.ax <<= 8;
+            ctx.regs.ax |= i as usize;
+        }
+
+        ctx.blocked = false;
+
+        Ok(cmp::min(mem::size_of::<usize>(), buf.len()))
+    }
+
+    // TODO implement seek?
+}

--- a/kernel/main.rs
+++ b/kernel/main.rs
@@ -498,7 +498,7 @@ pub extern "cdecl" fn kernel(interrupt: usize, mut regs: &mut Regs) {
         })
     };
 
-    //Do not catch init interrupt
+    // Do not catch init interrupt
     if interrupt < 0xFF {
         env().interrupts.lock()[interrupt as usize] += 1;
     }

--- a/kernel/schemes/context.rs
+++ b/kernel/schemes/context.rs
@@ -68,6 +68,9 @@ impl KScheme for ContextScheme {
                 if context.wake.is_some() {
                     flags_string.push('S');
                 }
+                if context.supervised {
+                    flags_string.push('T');
+                }
 
                 string.push_str(&format!("{:<6}{:<6}{:<8}{:<8}{:<8}{:<6}{:<6}{:<6}{}\n",
                                    context.pid,

--- a/kernel/syscall/mod.rs
+++ b/kernel/syscall/mod.rs
@@ -29,7 +29,11 @@ pub fn syscall_handle(regs: &mut Regs) {
                 cur.wake = None;
 
                 loop {
-                    unsafe { context_switch() };
+                    if cur.blocked {
+                        unsafe { context_switch() };
+                    } else {
+                        return;
+                    }
                 }
             }
         }


### PR DESCRIPTION
**Problem**: You cannot gain fine-grained control over a child process in Redox. This makes it possible to do things which are clasically covered by ptrace, seccomp, chroot and friends: to run another process in a restricted, traced, and supervised environment, which is useful for various purposes, such as emulation, virtualisation, logging, and debugging.

**Solution**: Introduce a new system call, SUPERVISE, which allows the parent process to handle the system calls of the child process, by blocking the child process when system calls are received.

**Changes introduced by this pull request**:

- Introduce a system call, SUPERVISE:

 SUPERVISE takes a PID specifing the process to be supervised. This PID must be a child process of the invoker. If not, EACCES will be returned.

 The process identified by the given PID will be restricted in such a way, that every syscall
made will mark the process as blocked and store the syscall until it is handled by the parrent.

 The return value (if successful) is a file descriptor, from which syscalls can be read and written: the syscalls are read in `Packet` sized packages, containing the respective blocking syscall. If no syscall is blocking (or the last blocking syscall have been handled), 0 bytes will be read to the buffer.

 Writing pointer sized integers to this file handle will set the EAX register of the particular
process, after which the process is unblocked and the syscall buffer is emptied. The behavior of writing packages of unexpected size is unspecified.

 Note that a process blocked by a syscall will have its potential sleep cleared (i.e., it will not wake up after the sleep is finished).

 Passing a non-existent PID results in ESRCH. 

- Add a flag, _CLONE_SUPERVISE_, to SYSCLONE. This flag will make the clone enter supervised mode immediately.
 This means that the process can run in supervised mode, even not being connected to a supervisor yet. In other words, the parent can later on supervise the process and handle the potential blocking syscall.

 This is an important security measure, since otherwise the process would be able to fork it self right after starting, making supervising it impossible.

- Add a `spawn_supervised` method to `Command`, which will spawn the command with the CLONE_SUPERVISED flag.

- Slightly refactor the `Command` internals to allow specifing arbitrary flags to SYS_CLONE.

**Drawbacks**: Increased complexity and surface area. One might argue that it, on a long-term basis, does the opposite: namely allow us to retain compatibility without introducing extra syscalls into the kernel.

**TODOs**:

- Security analysis.
- Add a `strace` tool to extrautils.
- Add a restrict tool to extrautils.
- Create a Linux compatibility layer.
- Allow handling certain non-0x80 interrupts?

There are no _known_ issues otherwise.

**State**: Ready, though it require future work (see TODO).

**Other**: sry for the eastereggs