### PR TITLE
Use EPERM/ESPIPE in the default implementation of Resource methods

### DIFF
--- a/kernel/fs/resource.rs
+++ b/kernel/fs/resource.rs
@@ -1,6 +1,6 @@
 use alloc::boxed::Box;
 
-use system::error::{Error, Result, EBADF};
+use system::error::{Error, Result, EPERM, ESPIPE};
 use system::syscall::Stat;
 
 /// Resource seek
@@ -18,41 +18,50 @@ pub enum ResourceSeek {
 #[allow(unused_variables)]
 pub trait Resource {
     /// Duplicate the resource
+    /// Returns `EPERM` if the operation is not supported.
     fn dup(&self) -> Result<Box<Resource>> {
-        Err(Error::new(EBADF))
+        Err(Error::new(EPERM))
     }
 
     /// Return the path of this resource
+    /// Returns `EPERM` if the operation is not supported.
     fn path(&self, buf: &mut [u8]) -> Result<usize> {
-        Err(Error::new(EBADF))
+        Err(Error::new(EPERM))
     }
 
     /// Read data to buffer
+    /// Returns `EPERM` if the operation is not supported.
     fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
-        Err(Error::new(EBADF))
+        Err(Error::new(EPERM))
     }
 
     /// Write to resource
+    /// Returns `EPERM` if the operation is not supported.
     fn write(&mut self, buf: &[u8]) -> Result<usize> {
-        Err(Error::new(EBADF))
+        Err(Error::new(EPERM))
     }
 
     /// Seek to the given offset
+    /// Returns `ESPIPE` if the operation is not supported.
     fn seek(&mut self, pos: ResourceSeek) -> Result<usize> {
-        Err(Error::new(EBADF))
+        Err(Error::new(ESPIPE))
     }
 
+    /// Get informations about the resource, such as mode and size
+    /// Returns `EPERM` if the operation is not supported.
     fn stat(&self, stat: &mut Stat) -> Result<usize> {
-        Err(Error::new(EBADF))
+        Err(Error::new(EPERM))
     }
 
     /// Sync all buffers
+    /// Returns `EPERM` if the operation is not supported.
     fn sync(&mut self) -> Result<()> {
-        Err(Error::new(EBADF))
+        Err(Error::new(EPERM))
     }
 
     /// Truncate to the given length
+    /// Returns `EPERM` if the operation is not supported.
     fn truncate(&mut self, len: usize) -> Result<()> {
-        Err(Error::new(EBADF))
+        Err(Error::new(EPERM))
     }
 }


### PR DESCRIPTION
**Problem**: In lots of syscalls (`close`, `dup`, ...) the same error (`EBADF`) is returned when the file descriptor is invalid and when the file descriptor is valid but the operation is not implemented for the current resource.     

**Solution**: Change the error returned by the default implementation of the `Resource` methods to `EPERM` (*Operation not permitted*), or `ESPIPE` (*Illegal seek*) for the `seek` method.

**Drawbacks**: If some code relies on the fact that the default implementation returns `EBADF`, il will break.

**State**: Ready