### PR TITLE
Return EPERM in the default KScheme implementation

### DIFF
--- a/kernel/fs/kscheme.rs
+++ b/kernel/fs/kscheme.rs
@@ -2,7 +2,7 @@ use super::{Resource, Url};
 
 use alloc::boxed::Box;
 
-use system::error::{Error, Result, ENOENT};
+use system::error::{Error, Result, EPERM};
 use system::syscall::Stat;
 
 #[allow(unused_variables)]
@@ -16,22 +16,22 @@ pub trait KScheme {
     }
 
     fn open(&mut self, path: Url, flags: usize) -> Result<Box<Resource>> {
-        Err(Error::new(ENOENT))
+        Err(Error::new(EPERM))
     }
 
     fn mkdir(&mut self, path: Url, flags: usize) -> Result<()> {
-        Err(Error::new(ENOENT))
+        Err(Error::new(EPERM))
     }
 
     fn rmdir(&mut self, path: Url) -> Result<()> {
-        Err(Error::new(ENOENT))
+        Err(Error::new(EPERM))
     }
 
     fn stat(&mut self, path: Url, stat: &mut Stat) -> Result<()> {
-        Err(Error::new(ENOENT))
+        Err(Error::new(EPERM))
     }
 
     fn unlink(&mut self, path: Url) -> Result<()> {
-        Err(Error::new(ENOENT))
+        Err(Error::new(EPERM))
     }
 }


### PR DESCRIPTION
**Problem**: The current default implementation of `KScheme` returns `ENOENT`. The problem is that this error is generally used when a path or resource descriptor does not point to a valid resource, so there **same** error can mean different things on a single syscall.

**Solution**: Return `EPERM` (*operation not permitted*) instead of `ENOENT`

**State**: Ready

**Related**: #612 