### PR TITLE
Bootstrap fuse dependency & more

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -82,8 +82,6 @@ archLinux()
 
 	echo "Installing fuse..."
 	sudo pacman -S fuse
-	echo "Running Redox setup scripts..."
-	sh redox/setup/arch.sh
 }
 
 ubuntu()
@@ -108,8 +106,6 @@ ubuntu()
 			echo "Virtualbox already installed!"
 		fi
 	fi
-	echo "Cloning Redox repo"
-	gitClone
 }
 
 fedora()
@@ -134,8 +130,6 @@ fedora()
 			echo "Virtualbox already installed!"
 		fi
 	fi
-	echo "Cloning Redox repo"
-	gitClone
 	echo "Installing necessary build tools..."
 	sudo dnf install gcc gcc-c++ glibc-devel.i686 nasm make libfuse-dev
 }
@@ -163,8 +157,6 @@ suse()
 			echo "Virtualbox already installed!"
 		fi
 	fi
-	echo "Cloning Redox repo..."
-	gitClone
 	echo "Installing necessary build tools..."
 	sudo zypper install gcc gcc-c++ glibc-devel-32bit nasm make libfuse
 }
@@ -202,7 +194,6 @@ usage()
 	echo "OPTIONS:"
 	echo
 	echo "   -h,--help      Show this prompt"
-	echo "   -b [branch]    Specify a branch of redox to clone"
 	echo "   -u [branch]    Update git repo and update rust"
 	echo "                  If blank defaults to master"
 	echo "   -e [emulator]  Install specific emulator, virtualbox or qemu"
@@ -296,6 +287,7 @@ fi
 
 if [ "$1" == "-u" ]; then
 	git pull origin master
+	git submodule update --recursive --init
 	multirust update nightly
 	exit
 fi

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -7,7 +7,6 @@ banner() {
 
 gitClone() {
 	git clone https://github.com/redox-os/redox.git --origin upstream --recursive
-	git submodule update --recursive --init
 }
 
 osx()
@@ -228,7 +227,7 @@ rustInstall() {
 		echo "\#curl -sSf https://static.rust-lang.org/rustup.sh | sh -s -- --channel=nightly"
 		exit 1
 	fi
-	
+
 	if hash 2>/dev/null multirust; then
 		multirust update nightly
 		multirust override nightly

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -228,6 +228,12 @@ rustInstall() {
 		echo "\#curl -sSf https://static.rust-lang.org/rustup.sh | sh -s -- --channel=nightly"
 		exit 1
 	fi
+	
+	if hash 2>/dev/null multirust; then
+		multirust update nightly
+		multirust override nightly
+	fi
+
 	if echo "$(rustc --version)" | grep -viq "nightly" ;then
 		echo "It appears that you have rust installed, but it"
 		echo "is not the nightly version, please either install"

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -241,7 +241,7 @@ rustInstall() {
 		echo "It appears that you have rust installed, but it"
 		echo "is not the nightly version, please either install"
 		echo "the nightly manually (not reccomended) or run this"
-		echo "script again, accepting the multirust install"
+		echo "script again, accepting the multirust install\n"
 	fi
 }
 
@@ -250,12 +250,12 @@ statusCheck() {
 	do
 	  if echo "$i" | grep -iq "last_build_status" ;then
 	    if echo "$i" | grep -iq 0 ;then
-				echo "********************************************"
+				echo "\n\n********************************************"
 	      echo "Travis reports that the last build succeded!"
 	      echo "Looks like you are good to go!"
 				echo "********************************************"
 	    else
-				echo "**************************************************"
+				echo "\n\n\**************************************************"
 	      echo "Travis reports that the last build *FAILED* :("
 	      echo "Might want to check out the issues before building"
 				echo "**************************************************"
@@ -271,7 +271,7 @@ endMessage()
 	rustInstall
 	echo "Cleaning up..."
 	rm bootstrap.sh
-	echo "---------------------------------------"
+	echo "\n---------------------------------------"
 	echo "Well it looks like you are ready to go!"
 	echo "---------------------------------------"
 	statusCheck

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -237,11 +237,15 @@ rustInstall() {
 		echo "\#curl -sSf https://static.rust-lang.org/rustup.sh | sh -s -- --channel=nightly"
 		exit 1
 	fi
-	if echo "$(rustc --version)" | grep -iq "nightly" ;then
+	if echo "$(rustc --version)" | grep -viq "nightly" ;then
 		echo "It appears that you have rust installed, but it"
 		echo "is not the nightly version, please either install"
 		echo "the nightly manually (not reccomended) or run this"
-		echo "script again, accepting the multirust install\n"
+		echo "script again, accepting the multirust install"
+		echo
+	else
+		echo "Your rust install looks good!"
+		echo
 	fi
 }
 
@@ -249,13 +253,15 @@ statusCheck() {
 	for i in $(echo "$(curl -sf https://api.travis-ci.org/repositories/redox-os/redox.json)" | tr "," "\n")
 	do
 	  if echo "$i" | grep -iq "last_build_status" ;then
-	    if echo "$i" | grep -iq 0 ;then
-				echo "\n\n********************************************"
+	    if echo "$i" | grep -iq "0" ;then
+				echo; echo;
+				echo "********************************************"
 	      echo "Travis reports that the last build succeded!"
 	      echo "Looks like you are good to go!"
 				echo "********************************************"
 	    else
-				echo "\n\n\**************************************************"
+				echo; echo;
+				echo "**************************************************"
 	      echo "Travis reports that the last build *FAILED* :("
 	      echo "Might want to check out the issues before building"
 				echo "**************************************************"
@@ -271,7 +277,8 @@ endMessage()
 	rustInstall
 	echo "Cleaning up..."
 	rm bootstrap.sh
-	echo "\n---------------------------------------"
+	echo
+	echo "---------------------------------------"
 	echo "Well it looks like you are ready to go!"
 	echo "---------------------------------------"
 	statusCheck

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -20,7 +20,7 @@ osx()
 			echo "Now installing git..."
 			brew install git
 		fi
-		if [ "$2" == "qemu" ]; then
+		if [ "$1" == "qemu" ]; then
 			if [ -z "$(which qemu-system-i386)" ]; then
 				echo "Installing qemu..."
 				brew install qemu
@@ -71,7 +71,7 @@ archLinux()
 		sudo pacman -S git
 	fi
 
-	if [ "$2" == "qemu" ]; then
+	if [ "$1" == "qemu" ]; then
 		if [ -z "$(which qemu-system-i386)" ]; then
 			echo "Installing QEMU..."
 			sudo pacman -S qemu
@@ -90,20 +90,20 @@ ubuntu()
 {
 	echo "Detected Ubuntu/Debian"
 	echo "Updating system..."
-	sudo "$3" update
+	sudo "$2" update
 	echo "Installing required packages..."
-	sudo "$3" install build-essential libc6-dev-i386 nasm curl file git libfuse-dev
-	if [ "$2" == "qemu" ]; then
+	sudo "$2" install build-essential libc6-dev-i386 nasm curl file git libfuse-dev
+	if [ "$1" == "qemu" ]; then
 		if [ -z "$(which qemu-system-i386)" ]; then
 			echo "Installing QEMU..."
-			sudo "$3" install qemu-system-x86 qemu-kvm
+			sudo "$2" install qemu-system-x86 qemu-kvm
 		else
 			echo "QEMU already installed!"
 		fi
 	else
 		if [ -z "$(which virtualbox)" ]; then
 			echo "Installing Virtualbox..."
-			sudo "$3" install virtualbox
+			sudo "$2" install virtualbox
 		else
 			echo "Virtualbox already installed!"
 		fi
@@ -119,7 +119,7 @@ fedora()
 		echo "Installing git..."
 		sudo yum install git-all
 	fi
-	if [ "$2" == "qemu" ]; then
+	if [ "$1" == "qemu" ]; then
 		if [ -z "$(which qemu-system-i386)" ]; then
 			echo "Installing QEMU..."
 			sudo yum install qemu-system-x86 qemu-kvm
@@ -147,7 +147,7 @@ suse()
 		echo "Installing git..."
 		zypper install git
 	fi
-	if [ "$2" == "qemu" ]; then
+	if [ "$1" == "qemu" ]; then
 		if [ -z "$(which qemu-system-i386)" ]; then
 			echo "Installing QEMU..."
 			sudo zypper install qemu-x86 qemu-kvm

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -50,7 +50,8 @@ osx()
 	brew tap homebrew/versions
 	brew install gcc49
 	brew tap Nashenas88/homebrew-gcc_cross_compilers
-	brew install i386-elf-binutils i386-elf-gcc nasm osxfuse
+	brew install i386-elf-binutils i386-elf-gcc nasm
+	brew install Caskroom/cask/osxfuse
 	endMessage
 }
 


### PR DESCRIPTION
**Problem**: Building Redox now depends on fuse

**Solution**: Add fuse to list of dependencies installed by the package managers

**Changes introduced by this pull request**:
- Add fuse to dependencies
- Clean up cloning, and rust install
- Added a function to report whether the last travis build was successful
- Changed rust install to multirust

It would be greatly appreciated if people could test it out on the various operating systems
to confirm that I got all the package names correct. Right now OSX and Arch are working 

`curl -sf https://raw.githubusercontent.com/DomThePorcupine/redox/master/bootstrap.sh -o bootstrap.sh && bash -e bootstrap.sh`
- [x] OSX
- [x] Arch Linux
- [x] Debian & derivatives
- [ ] Suse & derivatives
- [x] Fedora
- [x] Gentoo

------