### PR TITLE
Add data-layout fields to build targets.

### DIFF
--- a/i386-unknown-redox.json
+++ b/i386-unknown-redox.json
@@ -1,7 +1,8 @@
 {
-    "llvm-target": "i686-unknown-redox",
+    "llvm-target": "i386-unknown-redox",
     "target-endian": "little",
     "target-pointer-width": "32",
+    "data-layout": "e-m:e-p:32:32-f64:32:64-f80:32-n8:16:32-S128",
     "arch": "x86",
     "os": "redox",
     "env": "",

--- a/x86_64-unknown-redox.json
+++ b/x86_64-unknown-redox.json
@@ -2,6 +2,7 @@
     "llvm-target": "x86_64-unknown-redox",
     "target-endian": "little",
     "target-pointer-width": "64",
+    "data-layout": "e-m:e-i64:64-f80:128-n8:16:32:64-S128",
     "arch": "x86_64",
     "os": "redox",
     "env": "",


### PR DESCRIPTION
**Problem**: Breaking change in rust-lang/rust#32939 makes the current nightly refuse to build without a data-layout field in the target json. 

**Solution**: [Take the data-layout emitted by clang for the target-triple](https://github.com/rust-lang/rust/issues/31367#issuecomment-213595571) and add it to the target json.

**TODOs**: Validate that clang's defaults are what we want. [Documentation on data-layout format](http://llvm.org/docs/LangRef.html#data-layout)

**Fixes**: #620 

