### PR TITLE
Implement kernel logs and add the klog scheme

### DIFF
--- a/kernel/env/mod.rs
+++ b/kernel/env/mod.rs
@@ -9,6 +9,7 @@ use common::event::Event;
 use common::time::Duration;
 use disk::Disk;
 use fs::{KScheme, Resource, Scheme, VecResource, Url};
+use logging::LogLevel;
 use sync::WaitQueue;
 
 use system::error::{Error, Result, ENOENT, EEXIST};
@@ -35,6 +36,8 @@ pub struct Environment {
     pub disks: Intex<Vec<Box<Disk>>>,
     /// Pending events
     pub events: WaitQueue<Event>,
+    /// Kernel logs
+    pub logs: Intex<Vec<(LogLevel, String)>>,
     /// Schemes
     pub schemes: Intex<Vec<Box<KScheme>>>,
 
@@ -53,6 +56,7 @@ impl Environment {
             console: Intex::new(Console::new()),
             disks: Intex::new(Vec::new()),
             events: WaitQueue::new(),
+            logs: Intex::new(Vec::new()),
             schemes: Intex::new(Vec::new()),
 
             interrupts: Intex::new([0; 256]),

--- a/kernel/logging.rs
+++ b/kernel/logging.rs
@@ -1,0 +1,16 @@
+use collections::borrow::ToOwned;
+
+#[derive(Copy, Clone)]
+pub enum LogLevel {
+    Critical,
+    Error,
+    Warning,
+    Info,
+    Debug,
+}
+
+/// Add `message` to the kernel logs, with a priority level of `level`
+pub fn klog(level: LogLevel, message: &str) {
+    let mut logs = ::env().logs.lock();
+    logs.push((level, message.to_owned()));
+}

--- a/kernel/main.rs
+++ b/kernel/main.rs
@@ -61,6 +61,8 @@ use env::Environment;
 
 use graphics::display;
 
+use logging::{LogLevel, klog};
+
 use network::schemes::{ArpScheme, EthernetScheme, IcmpScheme, IpScheme, TcpScheme, UdpScheme};
 
 use schemes::context::ContextScheme;
@@ -71,6 +73,7 @@ use schemes::env::EnvScheme;
 //use schemes::file::FileScheme;
 use schemes::initfs::InitFsScheme;
 use schemes::interrupt::InterruptScheme;
+use schemes::klog::KlogScheme;
 use schemes::memory::MemoryScheme;
 use schemes::test::TestScheme;
 
@@ -140,6 +143,10 @@ pub mod fs;
 ///
 /// This module contains the initial display manager and various graphics primitives.
 pub mod graphics;
+/// Logging.
+///
+/// This module contains the `klog` function and the different log levels.
+pub mod logging;
 /// Networking.
 ///
 /// This module contains drivers (e.g, intel8254x and rtl8139), primitives, schemes, and data
@@ -374,6 +381,7 @@ unsafe fn init(tss_data: usize) {
             env.schemes.lock().push(box DisplayScheme);
             env.schemes.lock().push(box EnvScheme);
             env.schemes.lock().push(box InterruptScheme);
+            env.schemes.lock().push(box KlogScheme);
             env.schemes.lock().push(box MemoryScheme);
             env.schemes.lock().push(box TestScheme);
 
@@ -422,6 +430,7 @@ unsafe fn init(tss_data: usize) {
                     }
                 }
 
+                klog(LogLevel::Info, "The kernel has finished booting. Running /bin/init");
                 if let Err(err) = execute(vec!["initfs:/bin/init".to_string()]) {
                     debugln!("kernel: init: failed to execute: {}", err);
                 }

--- a/kernel/schemes/klog.rs
+++ b/kernel/schemes/klog.rs
@@ -1,0 +1,95 @@
+use fs::{KScheme, Resource, Url};
+use fs::resource::ResourceSeek;
+use collections::string::String;
+use alloc::boxed::Box;
+use system::error::Result;
+use logging::LogLevel;
+
+/// The kernel log scheme.
+pub struct KlogScheme;
+
+impl KScheme for KlogScheme {
+    /// Returns the name of the scheme: "klog"
+    fn scheme(&self) -> &str {
+        "klog"
+    }
+
+    /// Returns a resource. The `url` and `flags` arguments are currently unused.
+    fn open(&mut self, _: Url, _: usize) -> Result<Box<Resource>> {
+        Ok(Box::new(KlogResource {
+            pos: 0,
+        }))
+    }
+
+    /// Clears the logs.
+    fn unlink(&mut self, _: Url) -> Result<()> {
+        let mut logs = ::env().logs.lock();
+        logs.clear();
+        Ok(())
+    }
+}
+
+/// The kernel log resource.
+pub struct KlogResource {
+    pos: usize,
+}
+
+impl KlogResource {
+    fn get_log_str(&self) -> String {
+        let ref mut logs = *::env().logs.lock();
+        let mut string = String::new();
+        for &mut (ref level, ref message) in logs {
+            let prefix: &str = match *level {
+                LogLevel::Debug    => "DEBUG ",
+                LogLevel::Info     => "INFO  ",
+                LogLevel::Warning  => "WARN  ",
+                LogLevel::Error    => "ERROR ",
+                LogLevel::Critical => "CRIT  ",
+            };
+            string.push_str(prefix);
+            string.push_str(message);
+            string.push('\n');
+        }
+        string
+    }
+}
+
+impl Resource for KlogResource {
+    fn dup(&self) -> Result<Box<Resource>> {
+        Ok(Box::new(KlogResource {
+            pos: self.pos,
+        }))
+    }
+
+    /// Fills `buf` with the kernel log. Each message is prefixed by its log level:
+    /// - `CRIT`
+    /// - `ERROR`
+    /// - `WARN`
+    /// - `INFO`
+    /// - `DEBUG`
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
+        let mut i = 0;
+        let logs = self.get_log_str();
+        while i < buf.len() && self.pos < logs.bytes().count() {
+            match logs.bytes().nth(self.pos) {
+                Some(c) => buf[i] = c,
+                None => ()
+            }
+            i += 1;
+            self.pos += 1;
+        }
+        Ok(i)
+    }
+
+    fn seek(&mut self, pos: ResourceSeek) -> Result<usize> {
+        match pos {
+            ResourceSeek::Start(offset) => self.pos = offset as usize,
+            ResourceSeek::Current(offset) => self.pos += offset as usize,
+            ResourceSeek::End(offset) => {
+                let logs = self.get_log_str();
+                self.pos = (logs.bytes().count() as isize + offset) as usize;
+            }
+        }
+        Ok(self.pos)
+    }
+}

--- a/kernel/schemes/mod.rs
+++ b/kernel/schemes/mod.rs
@@ -12,6 +12,8 @@ pub mod env;
 pub mod initfs;
 /// Interrupt scheme
 pub mod interrupt;
+/// Logging scheme
+pub mod klog;
 /// Memory scheme
 pub mod memory;
 /// Pipes


### PR DESCRIPTION
**Problem**: The kernel doesn't keep logs, so if it wants to communicate with the user the only way is to print something on the screen. While this works well for critical errors (because you *want* the user to see them), it is excessive for warnings or simple informations.

**Solution**: Have the kernel keep tracks of info/warning/error logs, and let the users access them when they want to.

**Changes introduced by this pull request**:

- Add the `klog` function which add a message to the kernel logs.
- Add the `LogLevel` enum.
- Add the `klog` scheme

To read the kernel logs you can simply do:
```sh
$ cat klog:
```

**TODOs**:
- Maybe use a circular buffer to avoid using too much memory.
- Add a way read logs only of a certain priority level. Here is an example of the syntax that I'm thinking of:
```bash
$ cat klog:critical/error/warning
```
to view only critical/error/warning logs and
```bash
$ cat klog:!debug/!info
```
What do you think ?
to view everything except debug and info logs.

**State**: Ready.