### PR TITLE
Add libfuse to list of required dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ $ git clone git@github.com:redox-os/redox.git --origin upstream --recursive
 $ cd redox/
 
 # Install/update dependencies
-$ sudo <your package manager> install make nasm qemu
+$ sudo <your package manager> install make nasm qemu libfuse-dev
 
 # Install multirust
 $ curl -sf https://raw.githubusercontent.com/brson/multirust/master/quick-install.sh | sh


### PR DESCRIPTION
**Problem**: I didn't know that libfuse was needed, so I got build errors

**Solution**: Adds documentation to say that you need libfuse-dev
