### PR TITLE
Use fully-qualified name for gcc_cross_compilers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,10 @@ os:
   - linux
 before_install:
     - if [ `uname` = "Darwin" ]; then
-        brew tap altkatz/homebrew-gcc_cross_compilers;
+        brew tap nashenas88/gcc_cross_compilers;
         brew update;
         brew unlink gcc;
-        brew install i386-elf-binutils i386-elf-gcc nasm;
+        brew install nashenas88/gcc_cross_compilers/i386-elf-binutils nashenas88/gcc_cross_compilers/i386-elf-gcc nasm;
       fi
 script:
   - make clean

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -48,8 +48,8 @@ osx()
 	echo "Running Redox setup script..."
 	brew tap homebrew/versions
 	brew install gcc49
-	brew tap Nashenas88/homebrew-gcc_cross_compilers
-	brew install i386-elf-binutils i386-elf-gcc nasm pkg-config
+	brew tap nashenas88/gcc_cross_compilers
+	brew install nashenas88/gcc_cross_compilers/i386-elf-binutils nashenas88/gcc_cross_compilers/i386-elf-gcc nasm pkg-config
 	brew install Caskroom/cask/osxfuse
 	endMessage
 }

--- a/setup/osx-homebrew.sh
+++ b/setup/osx-homebrew.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 brew tap homebrew/versions
 brew install gcc49
-brew tap Nashenas88/homebrew-gcc_cross_compilers
-brew install i386-elf-binutils i386-elf-gcc nasm
+brew tap nashenas88/gcc_cross_compilers
+brew install nashenas88/gcc_cross_compilers/i386-elf-binutils nashenas88/gcc_cross_compilers/i386-elf-gcc nasm


### PR DESCRIPTION
If the user already has other gcc_cross_compilers kegs tapped, running
bootstrap.sh will result in:

====
Error: Formulae found in multiple taps:
 * altkatz/gcc_cross_compilers/i386-elf-binutils
 * nashenas88/gcc_cross_compilers/i386-elf-binutils

Please use the fully-qualified name e.g.
altkatz/gcc_cross_compilers/i386-elf-binutils to refer the formula.
====

Assume the user has other gcc_cross_compilers kegs already tapped and
accomodate for this.

***
As a side note, I don't quite understand the brew unlink gcc line in the travis.yml. Also, should pkg-config be added to the list of installed packages in that file? I see pkg-config is also missing in setup/osx-homebrew.sh. It's probably a bad idea to have duplicate code between bootstrap.sh and the setup folder as they will inevitably go out of sync. I'd be willing to create another pull request cleaning that up if desired.