### PR TITLE
Remove extra endMessage in bootstrap.sh

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -51,7 +51,6 @@ osx()
 	brew tap Nashenas88/homebrew-gcc_cross_compilers
 	brew install i386-elf-binutils i386-elf-gcc nasm pkg-config
 	brew install Caskroom/cask/osxfuse
-	endMessage
 }
 
 archLinux()


### PR DESCRIPTION
endMessage is called after the platform-specific logic so remove
the extra one in osx().