### PR TITLE
Show error on Unknown Make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -670,3 +670,8 @@ ping:
 
 wireshark:
 	wireshark $(BUILD)/network.pcap
+
+%:
+	@echo "ERROR: Unknown target. Maybe you forgot to get the submodules (git submodule update --init --recursive)"
+	exit 100
+


### PR DESCRIPTION
**Problem**: Make fails when submodules are missing

**Solution**: Suggests to get submodules on unknown target

**Changes introduced by this pull request**:

- Add a warning on a default target

**Drawbacks**: Make still shows the missing target, so it has no apparent drawbacks.

**TODOs**: -

**Fixes**: -

**State**: Ready

**Related**: #642
