### PR TITLE
Get file_manager working via ugly hack

### DIFF
--- a/filesystem/apps/file_manager/main.rs
+++ b/filesystem/apps/file_manager/main.rs
@@ -243,7 +243,7 @@ impl FileManager {
     fn get_parent_directory() -> Option<String> {
         match File::open("../") {
             Ok(parent_dir) => match parent_dir.path() {
-                Ok(path) => return Some(path.into_os_string().into_string().unwrap_or("/".to_string())),
+                Ok(path) => return Some(path.into_os_string().into_string().unwrap_or("/".to_string()).trim_left_matches("file:").to_string()),
                 Err(err) => println!("failed to get path: {}", err)
             },
             Err(err) => println!("failed to open parent dir: {}", err)


### PR DESCRIPTION
**Problem**: file_manager app can't go up into parent directories

**Solution**: trim the leading `file:` from the path returned by `get_parent_directory`

**Drawbacks**: Doesn't address the fact that something somewhere isn't handling paths with the scheme on them correctly.

**TODOs**: Find out where the bug really is.

**Fixes**: #644 

**State**: Ready