### PR TITLE
Fix orbital scheme's handling of embedded ':' char

### DIFF
--- a/crates/orbital/main.rs
+++ b/crates/orbital/main.rs
@@ -280,7 +280,7 @@ impl OrbitalScheme {
 
 impl Scheme for OrbitalScheme {
     fn open(&mut self, url: &str, _flags: usize, _mode: usize) -> Result<usize> {
-        let path = url.split(":").last().unwrap_or("");
+        let path = url.splitn(2, ":").last().unwrap_or("");
         let mut parts = path.split("/");
 
         let flags = parts.next().unwrap_or("");

--- a/filesystem/apps/file_manager/main.rs
+++ b/filesystem/apps/file_manager/main.rs
@@ -197,7 +197,7 @@ impl FileManager {
     fn get_parent_directory() -> Option<String> {
         match File::open("../") {
             Ok(parent_dir) => match parent_dir.path() {
-                Ok(path) => return Some(path.into_os_string().into_string().unwrap_or("/".to_string()).trim_left_matches("file:").to_string()),
+                Ok(path) => return Some(path.into_os_string().into_string().unwrap_or("/".to_string())),
                 Err(err) => println!("failed to get path: {}", err)
             },
             Err(err) => println!("failed to open parent dir: {}", err)


### PR DESCRIPTION
**Problem**: the `orbital:` scheme was incorrectly parsing urls that contained an embedded `:`. This made the file_manager app crash when it tried to set the window title to a path with the `file:` scheme included.

**Solution**: Split url at the first `:` only.

**TODOs**: Come up with a general way of escaping data passed into schemes?

**Fixes**: #645 #644 

