### PR TITLE
Switch to rustup

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,14 +1,20 @@
 #! /bin/bash
-banner() {
+
+##########################################################
+# This function is simply a banner to introduce the script
+##########################################################
+banner()
+{	
 	echo "|------------------------------------------|"
 	echo "|----- Welcome to the redox bootstrap -----|"
 	echo "|------------------------------------------|"
 }
 
-gitClone() {
-	git clone https://github.com/redox-os/redox.git --origin upstream --recursive
-}
-
+###############################################################################
+# This function takes care of installing all dependencies for building redox on
+# Mac OSX
+# @params:	$1 the emulator to install, virtualbox or qemu
+###############################################################################
 osx()
 {
 	echo "Detected OSX!"
@@ -36,6 +42,7 @@ osx()
 		fi
 	else
 		echo "Homebrew does not appear to be installed! Would you like me to install it?"
+		echo "*WARNING* this install involves a curl | sh style command"
 		printf "(Y/n): "
 		read -r installit
 		if [ "$installit" == "Y" ]; then
@@ -53,16 +60,21 @@ osx()
 	brew install Caskroom/cask/osxfuse
 }
 
+###############################################################################
+# This function takes care of installing all dependencies for building redox on
+# Arch linux
+# @params:	$1 the emulator to install, virtualbox or qemu
+###############################################################################
 archLinux()
 {
 	echo "Detected Arch Linux"
 	echo "Updating system..."
 	sudo pacman -Syu
 
-  if [ -z "$(which nasm)" ]; then
-      echo "Installing nasm..."
-      sudo pacman -S nasm
-  fi
+	if [ -z "$(which nasm)" ]; then
+		echo "Installing nasm..."
+		sudo pacman -S nasm
+	fi
 
 	if [ -z "$(which git)" ]; then
 		echo "Installing git..."
@@ -82,6 +94,12 @@ archLinux()
 	sudo pacman -S fuse
 }
 
+###############################################################################
+# This function takes care of installing all dependencies for building redox on
+# debian based linux
+# @params:	$1 the emulator to install, virtualbox or qemu
+# 		$2 the package manager to use	
+###############################################################################
 ubuntu()
 {
 	echo "Detected Ubuntu/Debian"
@@ -106,10 +124,15 @@ ubuntu()
 	fi
 }
 
+###############################################################################
+# This function takes care of installing all dependencies for building redox on
+# fedora linux
+# @params:	$1 the emulator to install, virtualbox or qemu
+###############################################################################
 fedora()
 {
 	echo "Detected Fedora"
-  if [ -z "$(which git)" ]; then
+	if [ -z "$(which git)" ]; then
 		echo "Installing git..."
 		sudo yum install git-all
 	fi
@@ -132,6 +155,11 @@ fedora()
 	sudo dnf install gcc gcc-c++ glibc-devel.i686 nasm make libfuse-dev
 }
 
+###############################################################################
+# This function takes care of installing all dependencies for building redox on
+# *suse linux
+# @params:	$1 the emulator to install, virtualbox or qemu
+###############################################################################
 suse()
 {
 	echo "Detected a suse"
@@ -159,6 +187,11 @@ suse()
 	sudo zypper install gcc gcc-c++ glibc-devel-32bit nasm make libfuse
 }
 
+##############################################################################
+# This function takes care of installing all dependencies for builing redox on
+# gentoo linux
+# @params:	$1 the emulator to install, virtualbox or qemu
+##############################################################################
 gentoo()
 {
 	echo "Detected Gentoo Linux"
@@ -183,6 +216,9 @@ gentoo()
 	fi
 }
 
+######################################################################
+# This function outlines the different options available for bootstrap
+######################################################################
 usage()
 {
 	echo "------------------------"
@@ -194,6 +230,7 @@ usage()
 	echo "   -h,--help      Show this prompt"
 	echo "   -u [branch]    Update git repo and update rust"
 	echo "                  If blank defaults to master"
+	echo "   -s             Check the status of the current travis build"
 	echo "   -e [emulator]  Install specific emulator, virtualbox or qemu"
 	echo "   -p [package    Choose an Ubuntu package manager, apt-fast or"
 	echo "       manager]   aptitude"
@@ -203,35 +240,60 @@ usage()
 	exit
 }
 
+####################################################################################
+# This function takes care of everything associated to rust, and the version manager
+# That controls it, it can install rustup and uninstall multirust as well as making 
+# sure that the correct version of rustc is selected by rustup
+####################################################################################
 rustInstall() {
-	if [ -z "$(which multirust)" ]; then
-		echo "You do not have multirust installed."
-		echo "We HIGHLY reccomend using multirust."
-		echo "Would you like to install it now?"
-		printf "(y/N): "
-		read mrust
-		if echo "$mrust" | grep -iq "^y" ;then
-			#install multirust
-			echo "Multirust will be installed!"
-			curl -sf https://raw.githubusercontent.com/brson/multirust/master/quick-install.sh | sh
-			multirust override nightly
+	# Check to see if multirust is installed, we don't want it messing with rustup
+	# In th future we can probably remove this but I believe it's good to have for now	
+	if hash 2>/dev/null multirust; then
+		echo "It appears that multirust is installed on your system."
+		echo "This tool has been depreciated by the maintainer, and will cause issues."
+		echo "This script can remove multirust from your system if you wish."
+		echo "*WARNING* this involves a 'curl | sh' style command"
+		printf "Uninstall multirust (y/N):"
+		read multirust
+		if echo "$multirust" | grep -iq "^y" ;then
+			curl -sf https://raw.githubusercontent.com/brson/multirust/master/blastoff.sh | sh -s -- --uninstall
 		else
-			echo "Multirust will not be installed!"
+			echo "Please manually uninstall multirust and any other versions of rust, then re-run bootstrap."
+			exit
 		fi
 	fi
+	# If rustup is not installed we should offer to install it for them	
+	if [ -z "$(which rustup)" ]; then
+		echo "You do not have rustup installed."
+		echo "We HIGHLY reccomend using rustup."
+		echo "Would you like to install it now?"
+		echo "*WARNING* this involves a 'curl | sh' style command"
+		printf "(y/N): "
+		read rustup
+		if echo "$rustup" | grep -iq "^y" ;then
+			#install rustup
+			curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain nightly
+			# You have to add the rustup variables to the $PATH	
+			echo "export PATH=\"\$HOME/.cargo/bin:\$PATH\"" >> ~/.bashrc	
+			rustup default nightly
+		else
+			echo "Rustup will not be installed!"
+		fi
+	fi	
+	# 	
 	if [ -z "$(which rustc)" ]; then
 		echo "Rust is not installed"
-		echo "Please either run the script again, accepting multirust install"
+		echo "Please either run the script again, accepting rustup install"
 		echo "or install rustc nightly manually (not reccomended) via:"
 		echo "\#curl -sSf https://static.rust-lang.org/rustup.sh | sh -s -- --channel=nightly"
-		exit 1
+		exit 
 	fi
-
-	if hash 2>/dev/null multirust; then
-		multirust update nightly
-		multirust override nightly
+	# If the system has rustup installed then update rustc to the latest nightly
+	if hash 2>/dev/null rustup; then
+		rustup update nightly
+		rustup default nightly
 	fi
-
+	# Check to make sure that the default rustc is the nightly
 	if echo "$(rustc --version)" | grep -viq "nightly" ;then
 		echo "It appears that you have rust installed, but it"
 		echo "is not the nightly version, please either install"
@@ -244,31 +306,46 @@ rustInstall() {
 	fi
 }
 
+####################################################################
+# This function gets the current build status from travis and prints 
+# a message to the user
+####################################################################
 statusCheck() {
 	for i in $(echo "$(curl -sf https://api.travis-ci.org/repositories/redox-os/redox.json)" | tr "," "\n")
 	do
-	  if echo "$i" | grep -iq "last_build_status" ;then
-	    if echo "$i" | grep -iq "0" ;then
-				echo; echo;
+		if echo "$i" | grep -iq "last_build_status" ;then
+			if echo "$i" | grep -iq "0" ;then
+				echo
 				echo "********************************************"
-	      echo "Travis reports that the last build succeded!"
-	      echo "Looks like you are good to go!"
+				echo "Travis reports that the last build succeded!"
+				echo "Looks like you are good to go!"
 				echo "********************************************"
-	    else
-				echo; echo;
+			elif echo "$i" | grep -iq "null" ;then
+				echo
+				echo "******************************************************************"	
+				echo "The Travis build did not finish, this is an error with its config."
+				echo "I cannot reliably determine whether the build is succeding or not."
+				echo "Consider checking for and maybe opening an issue on github"
+				echo "******************************************************************"
+			else
+				echo
 				echo "**************************************************"
-	      echo "Travis reports that the last build *FAILED* :("
-	      echo "Might want to check out the issues before building"
+				echo "Travis reports that the last build *FAILED* :("
+				echo "Might want to check out the issues before building"
 				echo "**************************************************"
-	    fi
-	  fi
+			fi
+		fi
 	done
 }
 
-endMessage()
+###########################################################################
+# This function is the main logic for the bootstrap; it clones the git repo
+# then it installs the rust version manager and the latest version of rustc
+###########################################################################
+boot()
 {
 	echo "Cloning github repo..."
-	gitClone
+	git clone https://github.com/redox-os/redox.git --origin upstream --recursive	
 	rustInstall
 	echo "Cleaning up..."
 	rm bootstrap.sh
@@ -277,22 +354,25 @@ endMessage()
 	echo "Well it looks like you are ready to go!"
 	echo "---------------------------------------"
 	statusCheck
-	echo "		cd redox"
-	echo "		make all"
-	echo "		make virtualbox or qemu"
+	echo "Run the following commands to build redox:"
+	echo "cd redox"
+	echo "make all"
+	echo "make virtualbox or qemu"
 	echo
 	echo "      Good luck!"
 
 	exit
 }
+
 if [ "$1" == "-h" ]; then
 	usage
-fi
-
-if [ "$1" == "-u" ]; then
+elif [ "$1" == "-u" ]; then
 	git pull origin master
 	git submodule update --recursive --init
-	multirust update nightly
+	rustup update nightly
+	exit
+elif [ "$1" == "-s" ]; then
+	statusCheck
 	exit
 fi
 
@@ -311,6 +391,7 @@ banner
 if [ "Darwin" == "$(uname -s)" ]; then
 	osx "$emulator"
 else
+	# Here we will user package managers to determine which operating system the user is using	
 	# Arch linux
 	if hash 2>/dev/null pacman; then
 		archLinux "$emulator"
@@ -332,4 +413,4 @@ else
 		gentoo "$emulator"
  	fi
 fi
-endMessage
+boot

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -248,19 +248,20 @@ usage()
 rustInstall() {
 	# Check to see if multirust is installed, we don't want it messing with rustup
 	# In th future we can probably remove this but I believe it's good to have for now	
-	if hash 2>/dev/null multirust; then
+	if [ -e /usr/local/lib/rustlib/uninstall.sh ] ; then
 		echo "It appears that multirust is installed on your system."
-		echo "This tool has been depreciated by the maintainer, and will cause issues."
+		echo "This tool has been deprecated by the maintainer, and will cause issues."
 		echo "This script can remove multirust from your system if you wish."
-		echo "*WARNING* this involves a 'curl | sh' style command"
 		printf "Uninstall multirust (y/N):"
 		read multirust
 		if echo "$multirust" | grep -iq "^y" ;then
-			curl -sf https://raw.githubusercontent.com/brson/multirust/master/blastoff.sh | sh -s -- --uninstall
+			sudo /usr/local/lib/rustlib/uninstall.sh	
 		else
 			echo "Please manually uninstall multirust and any other versions of rust, then re-run bootstrap."
 			exit
 		fi
+	else
+		echo "Old multirust not installed, you are good to go."
 	fi
 	# If rustup is not installed we should offer to install it for them	
 	if [ -z "$(which rustup)" ]; then
@@ -274,7 +275,9 @@ rustInstall() {
 			#install rustup
 			curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain nightly
 			# You have to add the rustup variables to the $PATH	
-			echo "export PATH=\"\$HOME/.cargo/bin:\$PATH\"" >> ~/.bashrc	
+			echo "export PATH=\"\$HOME/.cargo/bin:\$PATH\"" >> ~/.bashrc
+			# source the variables so that we can execute rustup commands in the current shell
+			source ~/.cargo/env	
 			rustup default nightly
 		else
 			echo "Rustup will not be installed!"
@@ -345,7 +348,7 @@ statusCheck() {
 boot()
 {
 	echo "Cloning github repo..."
-	git clone https://github.com/redox-os/redox.git --origin upstream --recursive	
+	#git clone https://github.com/redox-os/redox.git --origin upstream --recursive	
 	rustInstall
 	echo "Cleaning up..."
 	rm bootstrap.sh


### PR DESCRIPTION
**Problem**: `multirust` has been deprecated, we need to start using `rustup`!

**Solution**: Change the bootstrap file

**Changes introduced by this pull request**:
- Switch from `multirust` to `rustup`
- Add warnings that bootstrap uses `curl | sh` style commands to install things. I feel that I should have been warning people before, these type of commands can make people feel uncomfortable.
- Tried to start better documentation
- Added a new option, you can now run `./bootstrap -s` to see the current travis build status

**Fixes**: #651 

**State**: Ready-ish

**Other**: I'd like some feedback on the `rustInstall` function and how I handle trying to install rustup/uninstall multirust. Another issue involves the $PATH environment variable and making sure it is set properly I can set it in bashrc but i worry that it _might_ not work for people using something like zsh. @jackpot51 I'd appreciate it if a couple of you looked over things before it gets merged.