### PR TITLE
fix fuse pkg name on fedora

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -152,7 +152,7 @@ fedora()
 		fi
 	fi
 	echo "Installing necessary build tools..."
-	sudo dnf install gcc gcc-c++ glibc-devel.i686 nasm make libfuse-dev
+	sudo dnf install gcc gcc-c++ glibc-devel.i686 nasm make fuse-devel
 }
 
 ###############################################################################


### PR DESCRIPTION
**Problem**: 
Fails to build disk image on fedora since bootstrap.sh had the wrong package name for fuse-devel

**Solution**: 
Updated bootstrap.sh for fedora.

**State**:
Ready

