### PR TITLE
Remove deprecated feature zero_one

### DIFF
--- a/kernel/acpi/aml.rs
+++ b/kernel/acpi/aml.rs
@@ -1,7 +1,6 @@
 use collections::string::String;
 
 use core::mem::size_of;
-use core::num::Zero;
 use core::ops::{BitOrAssign, ShlAssign};
 
 const ZERO_OP: u8 = 0x00;
@@ -48,10 +47,10 @@ pub fn parse_string(bytes: &[u8], i: &mut usize) -> String {
 }
 
 // This one function required three different unstable features and four trait requirements. Why is generic math so hard?
-pub fn parse_num<T: BitOrAssign + From<u8> + ShlAssign<usize> + Zero>(bytes: &[u8],
+pub fn parse_num<T: BitOrAssign + From<u8> + ShlAssign<usize>>(bytes: &[u8],
                                                                       i: &mut usize)
                                                                       -> T {
-    let mut num: T = T::zero();
+    let mut num: T = T::from(0);
 
     let mut shift = 0;
     while *i < bytes.len() && shift < size_of::<T>() * 8 {

--- a/kernel/main.rs
+++ b/kernel/main.rs
@@ -2,10 +2,10 @@
 #![crate_type="staticlib"]
 #![feature(alloc, allocator, arc_counts, asm, box_syntax, collections, const_fn, core_intrinsics,
            fnbox, fundamental, lang_items, naked_functions, unboxed_closures, unsafe_no_drop_flag,
-           unwind_attributes, zero_one, collections_range, question_mark, type_ascription)]
+           unwind_attributes, collections_range, question_mark, type_ascription)]
 #![no_std]
 
-// #![deny(warnings)]
+#![deny(warnings)]
 // #![deny(missing_docs)]
 
 #[macro_use]


### PR DESCRIPTION
Restore `deny(warnings)`