### PR TITLE
Incorporate Reblox game into Redox OS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -241,7 +241,8 @@ games: \
 	filesystem/bin/h4xx3r \
 	filesystem/bin/minesweeper \
 	filesystem/bin/rusthello \
-	filesystem/bin/snake
+	filesystem/bin/snake \
+	filesystem/bin/reblox
 
 filesystem/bin/%: crates/%/main.rs crates/%/*.rs $(BUILD)/libstd.rlib
 	mkdir -p filesystem/bin


### PR DESCRIPTION
Reblox was just merged into games-for-redox repository. This PR makes Reblox available in Redox OS.