### PR TITLE
Avoid potential overflow in adding user-provided address and length

### DIFF
--- a/kernel/arch/context.rs
+++ b/kernel/arch/context.rs
@@ -533,10 +533,23 @@ impl ContextZone {
     /// Check permission of segment, if inside of mapped memory
     pub fn permission(&self, ptr: usize, len: usize, writeable: bool) -> bool {
         for mem in self.memory.iter() {
-            if ptr >= mem.virtual_address && ptr + len <= mem.virtual_address + mem.virtual_size {
-                if mem.writeable || ! writeable {
-                    return true;
-                }
+            if ptr < mem.virtual_address {
+                continue;
+            }
+            let end = mem.virtual_address + mem.virtual_size; // Presumably guaranteed not to overflow by construction
+            if ptr < mem.virtual_address {
+                continue;
+            }
+            if ptr >= end {
+                continue;
+            }
+            let max_len = end - ptr; // Guaranteed not to overflow by preceding check
+            if len > max_len {
+                continue;
+            }
+
+            if mem.writeable || ! writeable {
+                return true;
             }
         }
 


### PR DESCRIPTION
Both ptr and len are directly formed by user-supplied values. Malicious code making a system call could supply very large values, such that adding them together could produce an overflow.

In debug mode, the compiler-inserted checks would catch it, and presumably crash the kernel, producing a denial of service. In release mode, the wrapped value could pass the check, when it shouldn't, allowing the calling code to read or write data at an arbitrary address.

This change avoids ever adding them together, so that the threatened overflow can't happen. Here's the algebra showing that the final check is equivalent to the previous version in the non-overflowing case:

!(ptr + len <= mem.virtual_address + mem.virtual_size)
ptr + len > mem.virtual_address + mem.virtual_size
ptr + len > end
len > end - ptr
len > max_len

**TODOs**: 
- My changes are **completely untested** - I made them online in Github, without any local compilation, etc. I believe in the logic as written, but not in the syntax
- The corresponding check of the Stack segment later in this file also needs to be changed