### PR TITLE
Fix networking under VirtualBox

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -656,6 +656,7 @@ virtualbox: $(BUILD)/harddrive.bin
 	$(VBM) modifyvm Redox --vram 16
 	$(VBM) modifyvm Redox --nic1 nat
 	$(VBM) modifyvm Redox --nictype1 82540EM
+	$(VBM) modifyvm Redox --cableconnected1 on
 	$(VBM) modifyvm Redox --nictrace1 on
 	$(VBM) modifyvm Redox --nictracefile1 $(BUILD)/network.pcap
 	$(VBM) modifyvm Redox --uart1 0x3F8 4


### PR DESCRIPTION
**Problem**: When building Redox and running it under VirtualBox (`$ make all; make virtualbox`) the DHCP lease seems to fail and there is no network access (`$ ./dl_bmp.sh` hangs). This is reproducible on OS X 10.11.6 and VirtualBox 5.1.2.

**Solution**: In the VM's network adapter settings, setting the NIC's "Cable Connected" option solves the problem.

**Changes introduced by this pull request**:

- In the Makefile target responsible for creating the VirtualBox VM, an additional invocation of `modifyvm` is added to enable 'cableconnected'.