### PR TITLE
Use weak linkage for libc symbols

### DIFF
--- a/libstd/src/externs.rs
+++ b/libstd/src/externs.rs
@@ -6,6 +6,7 @@ pub static mut __errno: isize = 0;
 ///
 /// Copy N bytes of memory from one location to another.
 #[no_mangle]
+#[linkage = "weak"]
 pub unsafe extern fn memcpy(dest: *mut u8, src: *const u8,
                             n: usize) -> *mut u8 {
     let mut i = 0;
@@ -21,6 +22,7 @@ pub unsafe extern fn memcpy(dest: *mut u8, src: *const u8,
 ///
 /// Copy N bytes of memory from src to dest. The memory areas may overlap.
 #[no_mangle]
+#[linkage = "weak"]
 pub unsafe extern fn memmove(dest: *mut u8, src: *const u8,
                              n: usize) -> *mut u8 {
     if src < dest as *const u8 {
@@ -44,6 +46,7 @@ pub unsafe extern fn memmove(dest: *mut u8, src: *const u8,
 ///
 /// Fill a block of memory with a specified value.
 #[no_mangle]
+#[linkage = "weak"]
 pub unsafe extern fn memset(s: *mut u8, c: i32, n: usize) -> *mut u8 {
     let mut i = 0;
     while i < n {
@@ -58,6 +61,7 @@ pub unsafe extern fn memset(s: *mut u8, c: i32, n: usize) -> *mut u8 {
 ///
 /// Compare two blocks of memory.
 #[no_mangle]
+#[linkage = "weak"]
 pub unsafe extern fn memcmp(s1: *const u8, s2: *const u8, n: usize) -> i32 {
     let mut i = 0;
 

--- a/libstd/src/lib.rs
+++ b/libstd/src/lib.rs
@@ -25,6 +25,7 @@
 #![feature(heap_api)]
 #![feature(int_error_internals)]
 #![feature(lang_items)]
+#![feature(linkage)]
 #![feature(macro_reexport)]
 #![feature(naked_functions)]
 #![feature(oom)]


### PR DESCRIPTION
**Problem**: Linking both libstd and newlib causes duplicate symbol errors due to the symbols we define in extern.rs

**Solution**: Use weak linkage for the libc functions we define in libstd

**Drawbacks**: When linking both newlib and libstd, rust code will execute the newlib version of the functions.