### PR TITLE
Use goblin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -94,3 +94,6 @@
 [submodule "crates/sodium"]
 	path = crates/sodium
 	url = https://github.com/redox-os/sodium.git
+[submodule "crates/goblin"]
+	path = crates/goblin
+	url = http://github.com/m4b/goblin

--- a/Makefile
+++ b/Makefile
@@ -550,7 +550,10 @@ $(BUILD)/libsystem.rlib: crates/system/lib.rs crates/system/*.rs crates/system/*
 $(BUILD)/libredoxfs.rlib: crates/redoxfs/src/lib.rs crates/redoxfs/src/*.rs $(BUILD)/libstd.rlib
 	$(RUSTC) $(RUSTCFLAGS) -o $@ $<
 
-$(BUILD)/kernel.rlib: kernel/main.rs kernel/*.rs kernel/*/*.rs kernel/*/*/*.rs $(BUILD)/libbitflags.rlib $(BUILD)/libio.rlib $(BUILD)/libransid.rlib $(BUILD)/libsystem.rlib build/initfs.gen
+$(BUILD)/libgoblin.rlib: crates/goblin/src/lib.rs crates/goblin/src/elf/*/*.rs
+	$(RUSTC) $(RUSTCFLAGS) --cfg feature=\"no_mach\" --cfg feature=\"no_mach32\" --cfg feature=\"no_pe\" --cfg feature=\"no_pe32\" --cfg feature=\"no_endian_fd\" --cfg feature=\"pure\" --crate-name goblin --crate-type lib -o $@ $<
+
+$(BUILD)/kernel.rlib: kernel/main.rs kernel/*.rs kernel/*/*.rs kernel/*/*/*.rs $(BUILD)/libbitflags.rlib $(BUILD)/libio.rlib $(BUILD)/libransid.rlib $(BUILD)/libsystem.rlib $(BUILD)/libgoblin.rlib build/initfs.gen
 	$(RUSTC) $(RUSTCFLAGS) -C lto -o $@ $<
 
 $(BUILD)/kernel.bin: $(BUILD)/kernel.rlib kernel/kernel.ld

--- a/kernel/arch/elf.rs
+++ b/kernel/arch/elf.rs
@@ -2,19 +2,15 @@
 
 use collections::{String, Vec};
 
-use core::{mem, ptr, str, slice};
+use core::{ptr, str};
 
 use common::slice::GetSlice;
 
-pub use self::arch::*;
-
 #[cfg(target_arch = "x86")]
-#[path="x86/elf.rs"]
-mod arch;
+use goblin::elf32::{header, program_header};
 
 #[cfg(target_arch = "x86_64")]
-#[path="x86_64/elf.rs"]
-mod arch;
+use goblin::elf64::{header, program_header};
 
 /// An ELF executable
 pub struct Elf<'a> {
@@ -24,26 +20,26 @@ pub struct Elf<'a> {
 impl<'a> Elf<'a> {
     /// Create a ELF executable from data
     pub fn from(data: &'a [u8]) -> Result<Elf<'a>, String> {
-        if data.len() < mem::size_of::<ElfHeader>() {
-            Err(format!("Elf: Not enough data: {} < {}", data.len(), mem::size_of::<ElfHeader>()))
-        } else if data.get_slice(..4) != b"\x7FELF" {
-            Err(format!("Elf: Invalid magic: {:?} != {:?}", data.get_slice(..4), b"\x7FELF"))
-        } else if data.get(4) != Some(&ELF_CLASS) {
-            Err(format!("Elf: Invalid architecture: {:?} != {:?}", data.get(4), Some(&ELF_CLASS)))
+        if data.len() < header::SIZEOF_EHDR {
+            Err(format!("Elf: Not enough data: {} < {}", data.len(), header::SIZEOF_EHDR))
+        } else if data.get_slice(..header::SELFMAG) != header::ELFMAG {
+            Err(format!("Elf: Invalid magic: {:?} != {:?}", data.get_slice(..4), header::ELFMAG))
+        } else if data.get(header::EI_CLASS) != Some(&header::ELFCLASS) {
+            Err(format!("Elf: Invalid architecture: {:?} != {:?}", data.get(header::EI_CLASS), header::ELFCLASS))
         } else {
             Ok(Elf { data: data })
         }
     }
 
-    pub unsafe fn load_segment(&self) -> Vec<ElfSegment> {
+    pub unsafe fn load_segment(&self) -> Vec<program_header::ProgramHeader> {
         let mut segments = Vec::new();
 
-        let header = &*(self.data.as_ptr() as usize as *const ElfHeader);
+        let header = &*(self.data.as_ptr() as usize as *const header::Header);
 
-        for i in 0..header.ph_len {
-            let segment = ptr::read((self.data.as_ptr() as usize + header.ph_off as usize + i as usize * header.ph_ent_len as usize) as *const ElfSegment);
+        for i in 0..header.e_phnum {
+            let segment = ptr::read((self.data.as_ptr() as usize + header.e_phoff as usize + i as usize * header.e_phentsize as usize) as *const program_header::ProgramHeader);
 
-            if segment._type == 1 {
+            if segment.p_type == program_header::PT_LOAD {
                 segments.push(segment);
             }
         }
@@ -53,78 +49,7 @@ impl<'a> Elf<'a> {
 
     /// Get the entry field of the header
     pub unsafe fn entry(&self) -> usize {
-        let header = &*(self.data.as_ptr() as usize as *const ElfHeader);
-        header.entry as usize
-    }
-
-    /// ELF symbol
-    pub unsafe fn symbol(&self, name: &str) -> usize {
-        let header = &*(self.data.as_ptr() as usize as *const ElfHeader);
-
-        let sh_str_section =
-            &*((self.data.as_ptr() as usize + header.sh_off as usize +
-                header.sh_str_index as usize *
-                header.sh_ent_len as usize) as *const ElfSection);
-
-        let mut sym_section = &*((self.data.as_ptr() as usize + header.sh_off as usize) as *const ElfSection);
-
-        let mut str_section = &*((self.data.as_ptr() as usize + header.sh_off as usize) as *const ElfSection);
-
-        for i in 0..header.sh_len {
-            let section =
-                &*((self.data.as_ptr() as usize + header.sh_off as usize +
-                    i as usize *
-                    header.sh_ent_len as usize) as *const ElfSection);
-
-            let section_name_ptr =
-                (self.data.as_ptr() as usize + sh_str_section.off as usize + section.name as usize) as *const u8;
-            let mut section_name_len = 0;
-            for j in 0..4096 {
-                section_name_len = j;
-                if ptr::read(section_name_ptr.offset(j)) == 0 {
-                    break;
-                }
-            }
-            let section_name =
-                str::from_utf8_unchecked(slice::from_raw_parts(section_name_ptr,
-                                                               section_name_len as usize));
-
-            if section_name == ".symtab" {
-                sym_section = section;
-            } else if section_name == ".strtab" {
-                str_section = section;
-            }
-        }
-
-        if sym_section.off > 0 && str_section.off > 0 {
-            if sym_section.ent_len > 0 {
-                let len = sym_section.len / sym_section.ent_len;
-                for i in 0..len {
-                    let symbol = &*((self.data.as_ptr() as usize + sym_section.off as usize + i as usize * sym_section.ent_len as usize) as *const ElfSymbol);
-
-                    let symbol_name_ptr =
-                        (self.data.as_ptr() as usize + str_section.off as usize +
-                         symbol.name as usize) as *const u8;
-                    let mut symbol_name_len = 0;
-                    for j in 0..4096 {
-                        symbol_name_len = j;
-                        if ptr::read(symbol_name_ptr.offset(j)) == 0 {
-                            break;
-                        }
-                    }
-                    let symbol_name = str::from_utf8_unchecked(slice::from_raw_parts(symbol_name_ptr, symbol_name_len as usize));
-
-                    if name == symbol_name {
-                        return symbol.value as usize;
-                    }
-                }
-            } else {
-                debug!("No sym_section ent len\n");
-            }
-        } else {
-            debug!("No sym_section or str_section\n");
-        }
-
-        0
+        let header = &*(self.data.as_ptr() as usize as *const header::Header);
+        header.e_entry as usize
     }
 }

--- a/kernel/main.rs
+++ b/kernel/main.rs
@@ -19,6 +19,8 @@ extern crate collections;
 
 extern crate system;
 
+extern crate goblin;
+
 use acpi::Acpi;
 
 use alloc::boxed::Box;

--- a/kernel/syscall/execute.rs
+++ b/kernel/syscall/execute.rs
@@ -189,8 +189,8 @@ pub fn execute(mut args: Vec<String>) -> Result<usize> {
                         let image = unsafe { &mut *current.image.get() };
 
                         for segment in segments.iter() {
-                            let virtual_address = segment.vaddr as usize;
-                            let virtual_size = segment.mem_len as usize;
+                            let virtual_address = segment.p_vaddr as usize;
+                            let virtual_size = segment.p_memsz as usize;
 
                             let offset = virtual_address % 4096;
 
@@ -213,13 +213,13 @@ pub fn execute(mut args: Vec<String>) -> Result<usize> {
                             // Copy progbits
                             unsafe {
                                 ::memcpy(virtual_address as *mut u8,
-                                        executable.data.as_ptr().offset(segment.off as isize),
-                                        segment.file_len as usize)
+                                        executable.data.as_ptr().offset(segment.p_offset as isize),
+                                        segment.p_filesz as usize)
                             };
 
                             unsafe { memory.unmap() };
 
-                            memory.writeable = segment.flags & 2 == 2;
+                            memory.writeable = segment.p_flags & 2 == 2;
 
                             image.memory.push(memory);
                         }


### PR DESCRIPTION
Demonstrates switching to goblin as your ELF parser.  Feel free to not merge (also I'm based off a 2 week old master, sorry), just a suggestion (I've mostly been testing the pure switch and compiling your kernel as it's a good litmus test to make sure no std, fd, io, etc., is present)

Reasons you might want to switch:

1. If in the future you decide to pursue a dynamic linker in rust, as [dryad](http://github.com/m4b/dryad) has much of this work already implemented, and uses the same ELF backend.
2. It's fun
3. The symbol lookup function (while no currently used) isn't the the best way to lookup symbol names, using goblin's utilities would likely help