### PR TITLE
Update for rust nightly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ CARGO=CARGO_TARGET_DIR=build RUSTC="./rustc-$(ARCH).sh" cargo rustc
 CARGOFLAGS=--verbose --target=$(ARCH)-unknown-redox.json -- --cfg redox \
 	-L $(BUILD) \
 	-C no-prepopulate-passes -C no-stack-check -C opt-level=3 \
-	-Z no-landing-pads -Z orbit \
+	-Z no-landing-pads \
 	-A dead_code
 RUSTC=RUST_BACKTRACE=1 rustc
 RUSTDOC=rustdoc --target=$(ARCH)-unknown-redox.json --cfg redox -L $(BUILD) \

--- a/kernel/main.rs
+++ b/kernel/main.rs
@@ -1,7 +1,7 @@
 #![crate_name="kernel"]
 #![crate_type="staticlib"]
 #![feature(alloc, allocator, arc_counts, asm, box_syntax, collections, const_fn, core_intrinsics,
-           fnbox, fundamental, lang_items, naked_functions, unboxed_closures, unsafe_no_drop_flag,
+           fnbox, fundamental, lang_items, naked_functions, unboxed_closures,
            unwind_attributes, collections_range, question_mark, type_ascription)]
 #![no_std]
 

--- a/libstd/src/collections/hash_map.rs
+++ b/libstd/src/collections/hash_map.rs
@@ -76,7 +76,6 @@ mod raw_table {
     /// around just the "table" part of the hashtable. It enforces some
     /// invariants at the type level and employs some performance trickery,
     /// but in general is just a tricked out `Vec<Option<u64, K, V>>`.
-    #[unsafe_no_drop_flag]
     pub struct RawTable<K, V> {
         capacity: usize,
         size:     usize,
@@ -1016,7 +1015,7 @@ mod raw_table {
     impl<K, V> Drop for RawTable<K, V> {
         #[unsafe_destructor_blind_to_params]
         fn drop(&mut self) {
-            if self.capacity == 0 || self.capacity == mem::POST_DROP_USIZE {
+            if self.capacity == 0 {
                 return;
             }
 

--- a/libstd/src/lib.rs
+++ b/libstd/src/lib.rs
@@ -20,7 +20,6 @@
 #![feature(core_intrinsics)]
 #![feature(core_panic)]
 #![feature(dropck_parametricity)]
-#![feature(filling_drop)]
 #![feature(float_extras)]
 #![feature(heap_api)]
 #![feature(int_error_internals)]
@@ -40,7 +39,6 @@
 #![feature(type_ascription)]
 #![feature(unicode)]
 #![feature(unique)]
-#![feature(unsafe_no_drop_flag)]
 #![no_std]
 
 #![allow(deprecated)]


### PR DESCRIPTION
**Problem**: Rust now needs the Carrier trait for the `?` operator, but the libcore of the currently used rust commit contains no Carrier trait, so current rust fails building redox.
Also drop flags do not exist any more also causing redox to fail building.

**Solution**: Update the rust submodule to the latest commit and remove all references to unsafe_no_drop_flag and filling_drop

**Changes introduced by this pull request**:

- Rust submodule updated
- Remove references to `#![feature(unsafe_no_drop_flag)]`
- Remove references to `#[unsafe_no_drop_flag]`
- Remove references to `#![feature(filling_drop)]`

**Drawbacks**: Redox may not compile with currently good rust versions.

**Fixes**: #702 

**State**: ready, but does not solve the problem completely, because peg-rs does not compile on latest nightly

