### PR TITLE
kernel: improve syscall argument handling

### DIFF
--- a/kernel/arch/context.rs
+++ b/kernel/arch/context.rs
@@ -1020,13 +1020,17 @@ impl Context {
 
     /// Access a raw pointer safely
     pub fn get_slice<'a, T>(&'a self, ptr: *const T, len: usize) -> Result<&'a [T]> {
-        self.permission(ptr as usize, mem::size_of::<T>() * len, false)?;
+        if len > 0 {
+            self.permission(ptr as usize, mem::size_of::<T>() * len, false)?;
+        }
         Ok(unsafe { slice::from_raw_parts(ptr, len) })
     }
 
     /// Access a mutable raw pointer safely
     pub fn get_slice_mut<'a, T>(&'a self, ptr: *mut T, len: usize) -> Result<&'a mut [T]> {
-        self.permission(ptr as usize, mem::size_of::<T>() * len, true)?;
+        if len > 0 {
+            self.permission(ptr as usize, mem::size_of::<T>() * len, true)?;
+        }
         Ok(unsafe { slice::from_raw_parts_mut(ptr, len) })
     }
 

--- a/kernel/audio/intelhda.rs
+++ b/kernel/audio/intelhda.rs
@@ -134,7 +134,7 @@ impl Resource for IntelHdaResource {
                     tv_sec: 0,
                     tv_nsec: 0,
                 };
-                try!(syscall::time::nanosleep(&req, &mut rem));
+                try!(syscall::time::nanosleep(&req, Some(&mut rem)));
             }
 
             stream.interrupt = 0;

--- a/kernel/syscall/mod.rs
+++ b/kernel/syscall/mod.rs
@@ -55,27 +55,62 @@ pub fn name(number: usize) -> &'static str {
 ///
 /// The return value is placed in AX, unless otherwise specified.
 pub fn handle(regs: &mut Regs) {
-    {
-        let contexts = unsafe { &mut *::env().contexts.get() };
-        if let Ok(cur) = contexts.current_mut() {
-            cur.current_syscall = Some((regs.ip, regs.ax, regs.bx, regs.cx, regs.dx));
-            // debugln!("PID {}: {} @ {:X}: {} {} {:X} {:X} {:X}", cur.pid, cur.name, regs.ip, regs.ax, name(regs.ax), regs.bx, regs.cx, regs.dx);
-            if cur.supervised {
-                // Block the process.
-                cur.blocked_syscall = true;
-                cur.block("syscall::handle Supervise");
-                // Clear the timer.
-                cur.wake = None;
+    let contexts = unsafe { &mut *::env().contexts.get() };
+    let cur = contexts.current_mut().unwrap();
+    cur.current_syscall = Some((regs.ip, regs.ax, regs.bx, regs.cx, regs.dx));
+    // debugln!("PID {}: {} @ {:X}: {} {} {:X} {:X} {:X}", cur.pid, cur.name, regs.ip, regs.ax, name(regs.ax), regs.bx, regs.cx, regs.dx);
+    if cur.supervised {
+        // Block the process.
+        cur.blocked_syscall = true;
+        cur.block("syscall::handle Supervise");
+        // Clear the timer.
+        cur.wake = None;
 
-                loop {
-                    if cur.blocked > 0 {
-                        unsafe { context_switch() };
-                    } else {
-                        return;
-                    }
-                }
+        loop {
+            if cur.blocked > 0 {
+                unsafe { context_switch() };
+            } else {
+                return;
             }
         }
+    }
+
+    macro_rules! check {
+        ( $r:expr ) => (
+            match $r {
+                Err(result) => {
+                    regs.ax = -result.errno as usize;
+                    return;
+                },
+                Ok(val) => val,
+            }
+        )
+    }
+
+    macro_rules! get_ref {
+        ( $buf:ident, $typ:ty ) => ( check!(cur.get_ref(regs.$buf as *const $typ)) );
+    }
+
+    macro_rules! get_ref_mut {
+        ( $buf:ident, $typ:ty ) => ( check!(cur.get_ref_mut(regs.$buf as *mut $typ)) );
+    }
+
+    macro_rules! get_ref_mut_opt {
+        ( $buf:ident, $typ:ty ) => (
+            if regs.$buf != 0 {
+                Some(check!(cur.get_ref_mut(regs.$buf as *mut $typ)))
+            } else {
+                None
+            }
+        );
+    }
+
+    macro_rules! get_slice {
+        ( $buf:ident, $len:ident ) => ( check!(cur.get_slice(regs.$buf as *const u8, regs.$len)) );
+    }
+
+    macro_rules! get_slice_mut {
+        ( $buf:ident, $len:ident ) => ( check!(cur.get_slice_mut(regs.$buf as *mut u8, regs.$len)) );
     }
 
     let result = match regs.ax {
@@ -83,32 +118,32 @@ pub fn handle(regs: &mut Regs) {
         // once, to acheive the best performance.
 
         SYS_YIELD => process::sched_yield(),
-        SYS_FUTEX => process::futex(regs.bx as *mut i32, regs.cx, (regs.dx as isize) as i32, regs.si, regs.di as *mut i32),
-        SYS_WRITE => fs::write(regs.bx, regs.cx as *mut u8, regs.dx),
-        SYS_READ => fs::read(regs.bx, regs.cx as *mut u8, regs.dx),
+        SYS_FUTEX => process::futex(get_ref_mut!(bx, i32), regs.cx, (regs.dx as isize) as i32, regs.si, regs.di as *mut i32),
+        SYS_WRITE => fs::write(regs.bx, get_slice!(cx, dx)),
+        SYS_READ => fs::read(regs.bx, get_slice_mut!(cx, dx)),
         SYS_LSEEK => fs::lseek(regs.bx, regs.cx as isize, regs.dx),
-        SYS_OPEN => fs::open(regs.bx as *const u8, regs.cx, regs.dx),
+        SYS_OPEN => fs::open(get_slice!(bx, cx), regs.dx),
         SYS_CLOSE => fs::close(regs.bx),
         SYS_CLONE => process::clone(regs),
-        SYS_MKDIR => fs::mkdir(regs.bx as *const u8, regs.cx, regs.dx),
-        SYS_NANOSLEEP => time::nanosleep(regs.bx as *const TimeSpec, regs.cx as *mut TimeSpec),
-        SYS_FPATH => fs::fpath(regs.bx, regs.cx as *mut u8, regs.dx),
-        SYS_FSTAT => fs::fstat(regs.bx, regs.cx as *mut Stat),
+        SYS_MKDIR => fs::mkdir(get_slice!(bx, cx), regs.dx),
+        SYS_NANOSLEEP => time::nanosleep(get_ref!(bx, TimeSpec), get_ref_mut_opt!(cx, TimeSpec)),
+        SYS_FPATH => fs::fpath(regs.bx, get_slice_mut!(cx, dx)),
+        SYS_FSTAT => fs::fstat(regs.bx, get_ref_mut!(cx, Stat)),
         SYS_FSYNC => fs::fsync(regs.bx),
         SYS_FTRUNCATE => fs::ftruncate(regs.bx, regs.cx),
         SYS_DUP => fs::dup(regs.bx),
         SYS_IOPL => process::iopl(regs),
-        SYS_CLOCK_GETTIME => time::clock_gettime(regs.bx, regs.cx as *mut TimeSpec),
+        SYS_CLOCK_GETTIME => time::clock_gettime(regs.bx, get_ref_mut!(cx, TimeSpec)),
         SYS_EXECVE => process::execve(regs.bx as *const u8, regs.cx as *const *const u8),
         SYS_EXIT => process::exit(regs.bx),
         SYS_GETPID => process::getpid(),
         // TODO: link
-        SYS_PIPE2 => fs::pipe2(regs.bx as *mut usize, regs.cx),
-        SYS_RMDIR => fs::rmdir(regs.bx as *const u8, regs.cx),
-        SYS_UNLINK => fs::unlink(regs.bx as *const u8, regs.cx),
-        SYS_WAITPID => process::waitpid(regs.bx as isize, regs.cx as *mut usize, regs.dx),
+        SYS_PIPE2 => fs::pipe2(get_ref_mut!(bx, [usize; 2]), regs.cx),
+        SYS_RMDIR => fs::rmdir(get_slice!(bx, cx)),
+        SYS_UNLINK => fs::unlink(get_slice!(bx, cx)),
+        SYS_WAITPID => process::waitpid(regs.bx as isize, get_ref_mut_opt!(cx, usize), regs.dx),
         SYS_BRK => memory::brk(regs.bx),
-        SYS_CHDIR => fs::chdir(regs.bx as *const u8, regs.cx),
+        SYS_CHDIR => fs::chdir(get_slice!(bx, cx)),
         SYS_SUPERVISE => process::supervise(regs.bx),
         _ => Err(Error::new(ENOSYS)),
     };

--- a/kernel/syscall/time.rs
+++ b/kernel/syscall/time.rs
@@ -9,22 +9,18 @@ use syscall::{CLOCK_MONOTONIC, CLOCK_REALTIME, TimeSpec};
 use system::error::{Error, Result, EINVAL};
 
 /// Get the time of a given clock.
-pub fn clock_gettime(clock: usize, tp: *mut TimeSpec) -> Result<usize> {
-    let contexts = unsafe { & *::env().contexts.get() };
-    let current = contexts.current()?;
-    let tp_safe = current.get_ref_mut(tp)?;
-
+pub fn clock_gettime(clock: usize, tp: &mut TimeSpec) -> Result<usize> {
     match clock {
         CLOCK_REALTIME => {
             let clock_realtime = Duration::realtime();
-            tp_safe.tv_sec = clock_realtime.secs;
-            tp_safe.tv_nsec = clock_realtime.nanos;
+            tp.tv_sec = clock_realtime.secs;
+            tp.tv_nsec = clock_realtime.nanos;
             Ok(0)
         }
         CLOCK_MONOTONIC => {
             let clock_monotonic = Duration::monotonic();
-            tp_safe.tv_sec = clock_monotonic.secs;
-            tp_safe.tv_nsec = clock_monotonic.nanos;
+            tp.tv_sec = clock_monotonic.secs;
+            tp.tv_nsec = clock_monotonic.nanos;
             Ok(0)
         }
         _ => Err(Error::new(EINVAL)),
@@ -32,28 +28,23 @@ pub fn clock_gettime(clock: usize, tp: *mut TimeSpec) -> Result<usize> {
 }
 
 /// Sleep in N nanoseconds.
-pub fn nanosleep(req: *const TimeSpec, rem: *mut TimeSpec) -> Result<usize> {
+pub fn nanosleep(req: &TimeSpec, rem: Option<&mut TimeSpec>) -> Result<usize> {
     {
         let contexts = unsafe { &mut *::env().contexts.get() };
         let mut current = try!(contexts.current_mut());
 
         // Copied with * to avoid borrow issue on current.blocked = true
-        let req_safe = *current.get_ref(req)?;
+        let req = *req;
 
         current.block("nanosleep");
-        current.wake = Some(Duration::monotonic() + Duration::new(req_safe.tv_sec, req_safe.tv_nsec));
+        current.wake = Some(Duration::monotonic() + Duration::new(req.tv_sec, req.tv_nsec));
     }
 
     unsafe { context_switch(); }
 
-    {
-        let contexts = unsafe { & *::env().contexts.get() };
-        let current = try!(contexts.current());
-
-        if let Ok(rem_safe) = current.get_ref_mut(rem) {
-            rem_safe.tv_sec = 0;
-            rem_safe.tv_nsec = 0;
-        }
+    if let Some(rem) = rem {
+        rem.tv_sec = 0;
+        rem.tv_nsec = 0;
     }
 
     Ok(0)


### PR DESCRIPTION
**Problem**: Validation of syscall arguments is inconsistent.

Most syscall handlers correctly validate user-supplied pointers, but some don't, allowing a userspace process to read or modify kernel data.

**Solution**: Instead, do all argument validation in the syscall dispatcher before the specific handler is called. This restricts the usage of raw pointers as much as possible and makes it easier to verify that there is no unsafe behavior. 

**TODOs**: `exec` arguments are still not validated, since it's still using the old C-string ABI and it's more complicated to handle correctly.

**Other**: I saw that there was a kernel rewrite in progress after finishing this, but figured I might as well submit it.