### PR TITLE
Massaging linter with non_upper_case_globals.

### DIFF
--- a/kernel/common/random.rs
+++ b/kernel/common/random.rs
@@ -1,3 +1,4 @@
+#[allow(non_upper_case_globals)]
 static mut seed: u64 = 19940046431; //259261034506304368955239; //1706322144714608529217229883707268827757977089;
 
 /// Generate pseudo random number


### PR DESCRIPTION
**Problem**: Redox won't build with the latest Rust Nightly. See https://github.com/rust-lang/rust/issues/36258.

**Solution**: surgical use of `#[allow(non_upper_case_globals)]`

**TODOs**: Also needs to happen in `libstd`.

