### PR TITLE
Limited the length of logging messages.

### DIFF
--- a/kernel/logging.rs
+++ b/kernel/logging.rs
@@ -1,4 +1,4 @@
-use core::fmt::{self, Write};
+use core::fmt;
 
 use common::time::Duration;
 
@@ -59,7 +59,9 @@ pub fn syslog(level: LogLevel, message: &str) {
     syslog_inner(level, format_args!("{}", message));
 }
 
-//TODO: Limit log message size
+/// The maximal total length of a single log message, in bytes.
+const MAX_LOG_MESSAGE_SIZE: usize = 512;
+
 pub fn syslog_inner(level: LogLevel, message: fmt::Arguments) {
     let time = Duration::monotonic();
 
@@ -71,8 +73,10 @@ pub fn syslog_inner(level: LogLevel, message: fmt::Arguments) {
         LogLevel::Critical => ("CRIT  ", true),
     };
 
-    let _ = write!(unsafe { &mut *::env().log.get() }, "[{}.{:>03}] {}{}\n", time.secs, time.nanos/1000000, prefix, message);
+    let mut contents = format!("[{}.{:>03}] {}{}\n", time.secs, time.nanos/1000000, prefix, message);
+    contents.truncate(MAX_LOG_MESSAGE_SIZE);
+    let _ = unsafe { &mut *::env().log.get() }.write(contents.as_bytes());
     if display {
-        let _ = write!(::common::debug::SerialConsole::new(), "[{}.{:>03}] {}{}\n", time.secs, time.nanos/1000000, prefix, message);
+        let _ = ::common::debug::SerialConsole::new().write(contents.as_bytes());
     }
 }


### PR DESCRIPTION
This should take care of a FIXME left by @jackpot51 in kernel/logging.rs.