### PR TITLE
Use rdrand as seed for chacha prng, when available

### DIFF
--- a/schemes/randd/Cargo.toml
+++ b/schemes/randd/Cargo.toml
@@ -1,3 +1,6 @@
 [package]
 name = "randd"
 version = "0.1.0"
+
+[dependencies]
+raw-cpuid = "2.*"


### PR DESCRIPTION
**Problem**: The x86 instruction `rdrand` did not exist on my processor and was preventing redox from booting.

**Solution**: Only use `rdrand` when it exists.

**Changes introduced by this pull request**: Replaces invoking `rdrand` with ChaCha from the `rand` crate. If `rdrand` exists, use it to initialize ChaCha.

**Drawbacks**: randd will output the same stream of random numbers on each boot for the time being if `rdrand` does not exist.

**TODOs**: Initialize ChaCha some other way when `rdrand` does not exist.