### PR TITLE
increase process id range

### DIFF
--- a/kernel/context/mod.rs
+++ b/kernel/context/mod.rs
@@ -26,7 +26,7 @@ pub mod file;
 pub mod memory;
 
 /// Limit on number of contexts
-pub const CONTEXT_MAX_CONTEXTS: usize = 65536;
+pub const CONTEXT_MAX_CONTEXTS: usize = usize::max_value() - 1;
 
 /// Maximum context files
 pub const CONTEXT_MAX_FILES: usize = 65536;


### PR DESCRIPTION
**Problem**: The current number of possible process ids is very small and could easily lead to a reuse of those.

**Solution**: increase the range to usize::max_value() - 1

**Changes introduced by this pull request**:

CONTEXT_MAX_CONTEXTS

**Drawbacks**: the number pids is limited to usize maybe use u64 instead?

**TODOs**: nothing

**Fixes**: nothing

**State**: WIP

**Blocking/related**: nothing


