### PR TITLE
Minor improvements on schemes.

### DIFF
--- a/kernel/context/event.rs
+++ b/kernel/context/event.rs
@@ -3,6 +3,7 @@ use collections::BTreeMap;
 use spin::{Once, RwLock, RwLockReadGuard, RwLockWriteGuard};
 
 use context;
+use scheme::SchemeId;
 use sync::WaitQueue;
 use syscall::data::Event;
 
@@ -10,7 +11,7 @@ type EventList = Weak<WaitQueue<Event>>;
 
 #[derive(PartialEq, Eq, PartialOrd, Ord)]
 pub struct RegKey {
-    scheme_id: usize,
+    scheme_id: SchemeId,
     event_id: usize,
 }
 
@@ -39,7 +40,7 @@ pub fn registry_mut() -> RwLockWriteGuard<'static, Registry> {
     REGISTRY.call_once(init_registry).write()
 }
 
-pub fn register(fd: usize, scheme_id: usize, event_id: usize) -> bool {
+pub fn register(fd: usize, scheme_id: SchemeId, event_id: usize) -> bool {
     let (context_id, events) = {
         let contexts = context::contexts();
         let context_lock = contexts.current().expect("event::register: No context");
@@ -66,7 +67,7 @@ pub fn register(fd: usize, scheme_id: usize, event_id: usize) -> bool {
     }
 }
 
-pub fn unregister(fd: usize, scheme_id: usize, event_id: usize) {
+pub fn unregister(fd: usize, scheme_id: SchemeId, event_id: usize) {
     let mut registry = registry_mut();
 
     let mut remove = false;
@@ -91,7 +92,7 @@ pub fn unregister(fd: usize, scheme_id: usize, event_id: usize) {
     }
 }
 
-pub fn trigger(scheme_id: usize, event_id: usize, flags: usize, data: usize) {
+pub fn trigger(scheme_id: SchemeId, event_id: usize, flags: usize, data: usize) {
     let registry = registry();
     let key = RegKey {
         scheme_id: scheme_id,

--- a/kernel/context/file.rs
+++ b/kernel/context/file.rs
@@ -1,11 +1,13 @@
 //! File struct
 
+use scheme::SchemeId;
+
 /// A file
 //TODO: Close on exec
 #[derive(Copy, Clone, Debug)]
 pub struct File {
     /// The scheme that this file refers to
-    pub scheme: usize,
+    pub scheme: SchemeId,
     /// The number the scheme uses to refer to this file
     pub number: usize,
     /// If events are on, this is the event ID

--- a/kernel/scheme/debug.rs
+++ b/kernel/scheme/debug.rs
@@ -1,14 +1,15 @@
 use core::str;
-use core::sync::atomic::{AtomicUsize, Ordering, ATOMIC_USIZE_INIT};
+use core::sync::atomic::Ordering;
 use spin::Once;
 
 use context;
+use scheme::*;
 use sync::WaitQueue;
 use syscall::error::*;
 use syscall::flag::EVENT_READ;
 use syscall::scheme::Scheme;
 
-pub static DEBUG_SCHEME_ID: AtomicUsize = ATOMIC_USIZE_INIT;
+pub static DEBUG_SCHEME_ID: AtomicSchemeId = ATOMIC_SCHEMEID_INIT;
 
 /// Input queue
 static INPUT: Once<WaitQueue<u8>> = Once::new();

--- a/kernel/scheme/irq.rs
+++ b/kernel/scheme/irq.rs
@@ -1,14 +1,15 @@
 use core::{mem, str};
-use core::sync::atomic::{AtomicUsize, ATOMIC_USIZE_INIT, Ordering};
+use core::sync::atomic::Ordering;
 use spin::Mutex;
 
 use arch::interrupt::irq::acknowledge;
 use context;
+use scheme::{AtomicSchemeId, ATOMIC_SCHEMEID_INIT};
 use syscall::error::*;
 use syscall::flag::EVENT_READ;
 use syscall::scheme::Scheme;
 
-pub static IRQ_SCHEME_ID: AtomicUsize = ATOMIC_USIZE_INIT;
+pub static IRQ_SCHEME_ID: AtomicSchemeId = ATOMIC_SCHEMEID_INIT;
 
 /// IRQ queues
 static ACKS: Mutex<[usize; 16]> = Mutex::new([0; 16]);

--- a/kernel/scheme/pipe.rs
+++ b/kernel/scheme/pipe.rs
@@ -2,6 +2,7 @@ use alloc::arc::{Arc, Weak};
 use collections::{BTreeMap, VecDeque};
 use core::sync::atomic::{AtomicUsize, ATOMIC_USIZE_INIT, Ordering};
 use spin::{Mutex, Once, RwLock, RwLockReadGuard, RwLockWriteGuard};
+use scheme::{AtomicSchemeId, ATOMIC_SCHEMEID_INIT};
 
 use sync::WaitCondition;
 use syscall::error::{Error, Result, EBADF, EPIPE};
@@ -9,7 +10,7 @@ use syscall::flag::O_NONBLOCK;
 use syscall::scheme::Scheme;
 
 /// Pipes list
-pub static PIPE_SCHEME_ID: AtomicUsize = ATOMIC_USIZE_INIT;
+pub static PIPE_SCHEME_ID: AtomicSchemeId = ATOMIC_SCHEMEID_INIT;
 static PIPE_NEXT_ID: AtomicUsize = ATOMIC_USIZE_INIT;
 static PIPES: Once<RwLock<(BTreeMap<usize, PipeRead>, BTreeMap<usize, PipeWrite>)>> = Once::new();
 

--- a/kernel/scheme/root.rs
+++ b/kernel/scheme/root.rs
@@ -1,16 +1,16 @@
 use alloc::arc::Arc;
 use alloc::boxed::Box;
 use collections::BTreeMap;
-use core::sync::atomic::{AtomicUsize, ATOMIC_USIZE_INIT, Ordering};
+use core::sync::atomic::{AtomicUsize, Ordering};
 use spin::RwLock;
 
 use context;
 use syscall::error::*;
 use syscall::scheme::Scheme;
-use scheme;
+use scheme::{self, AtomicSchemeId, ATOMIC_SCHEMEID_INIT};
 use scheme::user::{UserInner, UserScheme};
 
-pub static ROOT_SCHEME_ID: AtomicUsize = ATOMIC_USIZE_INIT;
+pub static ROOT_SCHEME_ID: AtomicSchemeId = ATOMIC_SCHEMEID_INIT;
 
 pub struct RootScheme {
     next_id: AtomicUsize,

--- a/kernel/scheme/user.rs
+++ b/kernel/scheme/user.rs
@@ -1,6 +1,6 @@
 use alloc::arc::{Arc, Weak};
 use collections::BTreeMap;
-use core::sync::atomic::{AtomicUsize, AtomicU64, Ordering};
+use core::sync::atomic::{AtomicU64, Ordering};
 use core::{mem, slice, usize};
 use spin::{Mutex, RwLock};
 
@@ -10,6 +10,7 @@ use arch::paging::temporary_page::TemporaryPage;
 use context::{self, Context};
 use context::memory::Grant;
 use scheme::root::ROOT_SCHEME_ID;
+use scheme::{AtomicSchemeId, ATOMIC_SCHEMEID_INIT};
 use sync::{WaitQueue, WaitMap};
 use syscall::data::{Packet, Stat};
 use syscall::error::*;
@@ -20,7 +21,7 @@ use syscall::scheme::Scheme;
 pub struct UserInner {
     handle_id: usize,
     flags: usize,
-    pub scheme_id: AtomicUsize,
+    pub scheme_id: AtomicSchemeId,
     next_id: AtomicU64,
     context: Weak<RwLock<Context>>,
     todo: WaitQueue<Packet>,
@@ -33,7 +34,7 @@ impl UserInner {
         UserInner {
             handle_id: handle_id,
             flags: flags,
-            scheme_id: AtomicUsize::new(0),
+            scheme_id: ATOMIC_SCHEMEID_INIT,
             next_id: AtomicU64::new(1),
             context: context,
             todo: WaitQueue::new(),

--- a/kernel/syscall/process.rs
+++ b/kernel/syscall/process.rs
@@ -1062,3 +1062,4 @@ pub fn waitpid(pid: usize, status_ptr: usize, flags: usize) -> Result<usize> {
         }
     }
 }
+


### PR DESCRIPTION
Replace `usize` with `SchemeId` wherever applicable. This should remove a few footguns.
