### PR TITLE
bootstrap.sh: Make use of yum instead of dnf on Fedora

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -134,19 +134,19 @@ fedora()
 	echo "Detected Fedora"
 	if [ -z "$(which git)" ]; then
 		echo "Installing git..."
-		sudo yum install git-all
+		sudo dnf install git-all
 	fi
 	if [ "$1" == "qemu" ]; then
 		if [ -z "$(which qemu-system-i386)" ]; then
 			echo "Installing QEMU..."
-			sudo yum install qemu-system-x86 qemu-kvm
+			sudo dnf install qemu-system-x86 qemu-kvm
 		else
 			echo "QEMU already installed!"
 		fi
 	else
 		if [ -z "$(which virtualbox)" ]; then
 			echo "Installing virtualbox..."
-			sudo yum install virtualbox
+			sudo dnf install virtualbox
 		else
 			echo "Virtualbox already installed!"
 		fi
@@ -439,7 +439,7 @@ else
 		ubuntu "$emulator" "$defpackman"
 	fi
 	# Fedora
-	if hash 2>/dev/null yum; then
+	if hash 2>/dev/null dnf; then
 		fedora "$emulator"
 	fi
 	# Suse and derivatives


### PR DESCRIPTION
Fully adapt this script to using dnf instead of yum on Fedora.

**Problem**:
Fedora ships dnf in all supported versions replacing yum in default installations. If a user doesn't have yum installed, detection of Fedora and installation of packages might fail.

**Solution**:
dnf is mostly a drop-in replacement for yum so you can just swap command names

**Changes introduced by this pull request**:
- replace usage of yum through dnf
- update detection of fedora installation to use dnf instead of yum

**Drawbacks**:
Old (outdated and unsupported) installations of Fedora will not be able to run this script correctly any more. This is true for Fedora ≤ 21, Fedora 22 was released 2.5 years ago. Some ultra-conservative users keep using yum instead of dnf, they will see this script failing but probably won't be using "bleeding-edge" technology like Rust anyway.

**TODOs**:
None

**Fixes**:
None

**State**:
ready to be merged

**Blocking/related**:
None