### PR TITLE
bootstrap.sh: Fix naming origin

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -405,7 +405,7 @@ boot()
 if [ "$1" == "-h" ]; then
 	usage
 elif [ "$1" == "-u" ]; then
-	git pull origin master
+	git pull upstream master
 	git submodule update --recursive --init
 	rustup update nightly
 	exit


### PR DESCRIPTION
**Problem**:
By default, running bootstrap.sh doesn't work because in line 386, origin repo is named "upstream", but in line 408 it was called "origin".

**Solution**:
Always name origin "upstream"

**Drawbacks**:
Breaks updating your local repository from upstream if you named origin repo "origin".

**TODOs**:
Nothing

**State**:
ready

**Blocking/related**:
None