### PR TITLE
Makefile: fix filesystem permissions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,7 @@ clean:
 	cargo clean --manifest-path schemes/redoxfs/Cargo.toml
 	cargo clean --manifest-path schemes/tcpd/Cargo.toml
 	cargo clean --manifest-path schemes/udpd/Cargo.toml
+	-$(FUMOUNT) $(BUILD)/filesystem/
 	rm -rf initfs/bin
 	rm -rf filesystem/bin
 	rm -rf build
@@ -434,6 +435,7 @@ $(BUILD)/filesystem.bin: \
 		filesystem/bin/sh \
 		filesystem/bin/smith \
 		filesystem/bin/tar
+	-$(FUMOUNT) $(BUILD)/filesystem/
 	rm -rf $@ $(BUILD)/filesystem/
 	echo exit | cargo run --manifest-path schemes/redoxfs/Cargo.toml --bin redoxfs-utility $@ 256
 	mkdir -p $(BUILD)/filesystem/
@@ -442,14 +444,19 @@ $(BUILD)/filesystem.bin: \
 	sleep 2
 	pgrep redoxfs-fuse
 	cp -RL filesystem/* $(BUILD)/filesystem/
-	chown -R 0:0 $(BUILD)/filesystem/
-	chown -R 1000:1000 $(BUILD)/filesystem/home/user/
-	chmod 700 $(BUILD)/filesystem/root/
-	chmod 700 $(BUILD)/filesystem/home/user/
+	chmod -R uog+rX $(BUILD)/filesystem
+	chmod -R uog-w $(BUILD)/filesystem
+	chmod -R 555 $(BUILD)/filesystem/bin/
+	chmod -R u+rwX $(BUILD)/filesystem/root
+	chmod -R og-rwx $(BUILD)/filesystem/root
+	chmod -R u+rwX $(BUILD)/filesystem/home/user
+	chmod -R og-rwx $(BUILD)/filesystem/home/user
 	chmod +s $(BUILD)/filesystem/bin/su
 	chmod +s $(BUILD)/filesystem/bin/sudo
 	mkdir $(BUILD)/filesystem/tmp
 	chmod 1777 $(BUILD)/filesystem/tmp
+	chown -R 0:0 $(BUILD)/filesystem
+	chown -R 1000:1000 $(BUILD)/filesystem/home/user
 	sync
 	-$(FUMOUNT) $(BUILD)/filesystem/
 	rm -rf $(BUILD)/filesystem/


### PR DESCRIPTION
**Problem**:
* On my build machine with umask set to 0077, folders and executables were created with incorrect permissions, preventing redox from booting up correctly, most notably being unable to do anything as user.
* Some permissions were wrong, e.g. on /etc/passwd
* when build failed, filesystem was kept mounted under some circumstances, leaving a broken build directory

**Solution**:
* set right permissions even if build machine has umask 0077
* /etc/passwd must not be readable by user
* include directories for setting permissions
* make sure filesystem gets unmounted if build fails
* exclude others from /home/user and /root directories
* set executable bit in /bin/ even if build machine umask tries to prevent that

**Changes introduced by this pull request**:
- permissions
- unmounting filesystem more often if build fails

**Drawbacks**:
Unclear: When starting the file manager, I get a bunch of errors:
```
Failed to load icon inode-directory: failed to open image: Permission denied (os error 13)
Failed to load icon audio-x-wav: failed to open image: Permission denied (os error 13)
Failed to load icon application-x-executable: failed to open image: Permission denied (os error 13)
Failed to load icon image-x-generic: failed to open image: Permission denied (os error 13)
Failed to load icon image-x-generic: failed to open image: Permission denied (os error 13)
Failed to load icon text-x-makefile: failed to open image: Permission denied (os error 13)
Failed to load icon application-x-object: failed to open image: Permission denied (os error 13)
Failed to load icon text-x-makefile: failed to open image: Permission denied (os error 13)
Failed to load icon text-x-makefile: failed to open image: Permission denied (os error 13)
Failed to load icon text-x-csrc: failed to open image: Permission denied (os error 13)
Failed to load icon text-x-c++src: failed to open image: Permission denied (os error 13)
Failed to load icon text-x-chdr: failed to open image: Permission denied (os error 13)
Failed to load icon text-x-script: failed to open image: Permission denied (os error 13)
Failed to load icon text-x-script: failed to open image: Permission denied (os error 13)
Failed to load icon text-x-script: failed to open image: Permission denied (os error 13)
Failed to load icon text-x-script: failed to open image: Permission denied (os error 13)
Failed to load icon text-x-generic: failed to open image: Permission denied (os error 13)
Failed to load icon text-x-generic: failed to open image: Permission denied (os error 13)
Failed to load icon text-x-generic: failed to open image: Permission denied (os error 13)
Failed to load icon text-x-generic: failed to open image: Permission denied (os error 13)
Failed to load icon text-x-generic: failed to open image: Permission denied (os error 13)
Failed to load icon text-x-generic: failed to open image: Permission denied (os error 13)
Failed to load icon unknown: failed to open image: Permission denied (os error 13)
```
I think they are not related to my changes, but I'm not sure. Can somebody please check this?

**TODOs**:
See Drawbacks. I need somebody else to check I'm not wrong.

**Fixes**:
None reported to github.

**State**:
Ready except for the single TODO above.

**Blocking/related**:
None