### PR TITLE
add additional dependencies for MacOS users

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,15 @@ $ git clone git@github.com:redox-os/redox.git --origin upstream --recursive
 $ cd redox/
 
 # Install/update dependencies
-$ sudo <your package manager> install make nasm qemu libfuse-dev
+$ sudo <your package manager> install make nasm qemu
+
+# Additional dependencies for Linux Users
+$ sudo <your package manager> install libfuse-dev
+
+# Additional dependencies for MacOS Users
+# Download and Install OSFuse: https://github.com/osxfuse/osxfuse/releases
+$ sudo <your package manager> install pkg-config x86_64-elf-gcc
+# Note: `x86_64-elf-gcc` does not seem to be available via homebrew
 
 # Install rustup.rs
 $ curl https://sh.rustup.rs -sSf | sh


### PR DESCRIPTION
**Problem**: Currently the install/update dependencies description seemed to be only targeted at Linux Users.

**Solution**: In This PR I separated out the dependency that's for Linux Users only, and added extra dependencies for MacOS Users.
