### PR TITLE
update bootstrap.sh script

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,14 +127,7 @@ $ git clone git@github.com:redox-os/redox.git --origin upstream --recursive
 $ cd redox/
 
 # Install/update dependencies
-# Linux Users:
-$ sudo <your package manager> install make nasm qemu libfuse-dev
-# MacOS Users using MacPorts:
-$ sudo port install make nasm qemu gcc49 pkg-config osxfuse x86_64-elf-gcc
-# MacOS Users using Hombrew:
-$ brew install make nasm qemu gcc49 pkg-config Caskroom/cask/osxfuse
-$ brew tap glendc/gcc_cross_compilers
-$ brew install glendc/gcc_cross_compilers/x64-elf-binutils glendc/gcc_cross_compilers/x64-elf-gcc
+$ bash bootstrap.sh -d
 
 # Install rustup.rs
 $ curl https://sh.rustup.rs -sSf | sh


### PR DESCRIPTION
+ macOS users using MacPorts are now supported (fix issue #720);
+ dependencies for macOS users using brew have been updated;
+ the boot step can now be skipped with the '-d' flag, effectively only installing dependencies