### PR TITLE
Making file handles, context ids, scheme ids type-safer and better self-documented.

### DIFF
--- a/kernel/common/int_like.rs
+++ b/kernel/common/int_like.rs
@@ -1,0 +1,108 @@
+//! Helpers used to define types that are backed by integers (typically `usize`),
+//! without compromising safety.
+//!
+//! # Example
+//!
+//! ```
+//! /// Define an opaque type `Pid` backed by a `usize`.
+//! int_like!(Pid, usize);
+//!
+//! const ZERO: Pid = Pid::from(0);
+//! ```
+//!
+//! # Example
+//!
+//! ```
+//! /// Define opaque types `Pid` and `AtomicPid`, backed respectively by a `usize`
+//! /// and a `AtomicUsize`.
+//!
+//! int_like!(Pid, AtomicPid, usize, AtomicUsize);
+//!
+//! const ZERO: Pid = Pid::from(0);
+//! let ATOMIC_PID: AtomicPid = AtomicPid::default();
+//! ```
+
+#[macro_export]
+macro_rules! int_like {
+    ($new_type_name:ident, $backing_type: ident) => {
+        #[derive(PartialEq, Eq, PartialOrd, Ord, Debug, Clone, Copy)]
+        pub struct $new_type_name($backing_type);
+
+        impl $new_type_name {
+            pub const fn into(self) -> $backing_type {
+                self.0
+            }
+            pub const fn from(x: $backing_type) -> Self {
+                $new_type_name(x)
+            }
+        }
+    };
+
+    ($new_type_name:ident, $new_atomic_type_name: ident, $backing_type:ident, $backing_atomic_type:ident) => {
+        int_like!($new_type_name, $backing_type);
+
+        /// A mutable holder for T that can safely be shared among threads.
+        /// Runtime equivalent to using `AtomicUsize`, just type-safer.
+        pub struct $new_atomic_type_name {
+            container: $backing_atomic_type,
+        }
+
+        impl $new_atomic_type_name {
+            pub const fn new(x: $new_type_name) -> Self {
+                $new_atomic_type_name {
+                    container: $backing_atomic_type::new(x.into())
+                }
+            }
+            pub const fn default() -> Self {
+                Self::new($new_type_name::from(0))
+            }
+            pub fn load(&self, order: ::core::sync::atomic::Ordering) -> $new_type_name {
+                $new_type_name::from(self.container.load(order))
+            }
+            pub fn store(&self, val: $new_type_name, order: ::core::sync::atomic::Ordering) {
+                self.container.store(val.into(), order)
+            }
+            #[allow(dead_code)]
+            pub fn swap(&self, val: $new_type_name, order: ::core::sync::atomic::Ordering) -> $new_type_name {
+                $new_type_name::from(self.container.swap(val.into(), order))
+            }
+            #[allow(dead_code)]
+            pub fn compare_and_swap(&self, current: $new_type_name, new: $new_type_name, order: ::core::sync::atomic::Ordering) -> $new_type_name {
+                $new_type_name::from(self.container.compare_and_swap(current.into(), new.into(), order))
+            }
+            #[allow(dead_code)]
+            pub fn compare_exchange(&self, current: $new_type_name, new: $new_type_name, success: ::core::sync::atomic::Ordering, failure: ::core::sync::atomic::Ordering) -> ::core::result::Result<$new_type_name, $new_type_name> {
+                match self.container.compare_exchange(current.into(), new.into(), success, failure) {
+                    Ok(result) => Ok($new_type_name::from(result)),
+                    Err(result) => Err($new_type_name::from(result))
+                }
+            }
+            #[allow(dead_code)]
+            pub fn compare_exchange_weak(&self, current: $new_type_name, new: $new_type_name, success: ::core::sync::atomic::Ordering, failure: ::core::sync::atomic::Ordering) -> ::core::result::Result<$new_type_name, $new_type_name> {
+                match self.container.compare_exchange_weak(current.into(), new.into(), success, failure) {
+                    Ok(result) => Ok($new_type_name::from(result)),
+                    Err(result) => Err($new_type_name::from(result))
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+fn test() {
+    use core::mem::size_of;
+    use ::core::sync::atomic::AtomicUsize;
+
+    // Generate type `usize_like`.
+    int_like!(UsizeLike, usize);
+    const ZERO: UsizeLike = UsizeLike::from(0);
+    assert_eq!(size_of::<UsizeLike>(), size_of::<usize>());
+
+
+    // Generate types `usize_like` and `AtomicUsize`.
+    int_like!(UsizeLike2, AtomicUsizeLike, usize, AtomicUsize);
+    assert_eq!(size_of::<UsizeLike2>(), size_of::<usize>());
+    assert_eq!(size_of::<AtomicUsizeLike>(), size_of::<AtomicUsize>());
+}
+
+

--- a/kernel/common/mod.rs
+++ b/kernel/common/mod.rs
@@ -1,0 +1,3 @@
+#[macro_use]
+#[macro_export]
+pub mod int_like;

--- a/kernel/context/event.rs
+++ b/kernel/context/event.rs
@@ -17,7 +17,7 @@ pub struct RegKey {
 
 #[derive(PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProcessKey {
-    context_id: usize,
+    context_id: context::context::ContextId,
     fd: usize,
 }
 

--- a/kernel/context/event.rs
+++ b/kernel/context/event.rs
@@ -3,6 +3,7 @@ use collections::BTreeMap;
 use spin::{Once, RwLock, RwLockReadGuard, RwLockWriteGuard};
 
 use context;
+use scheme::SchemeId;
 use sync::WaitQueue;
 use syscall::data::Event;
 
@@ -10,7 +11,7 @@ type EventList = Weak<WaitQueue<Event>>;
 
 #[derive(PartialEq, Eq, PartialOrd, Ord)]
 pub struct RegKey {
-    scheme_id: usize,
+    scheme_id: SchemeId,
     event_id: usize,
 }
 
@@ -39,7 +40,7 @@ pub fn registry_mut() -> RwLockWriteGuard<'static, Registry> {
     REGISTRY.call_once(init_registry).write()
 }
 
-pub fn register(fd: usize, scheme_id: usize, event_id: usize) -> bool {
+pub fn register(fd: usize, scheme_id: SchemeId, event_id: usize) -> bool {
     let (context_id, events) = {
         let contexts = context::contexts();
         let context_lock = contexts.current().expect("event::register: No context");
@@ -66,7 +67,7 @@ pub fn register(fd: usize, scheme_id: usize, event_id: usize) -> bool {
     }
 }
 
-pub fn unregister(fd: usize, scheme_id: usize, event_id: usize) {
+pub fn unregister(fd: usize, scheme_id: SchemeId, event_id: usize) {
     let mut registry = registry_mut();
 
     let mut remove = false;
@@ -91,7 +92,7 @@ pub fn unregister(fd: usize, scheme_id: usize, event_id: usize) {
     }
 }
 
-pub fn trigger(scheme_id: usize, event_id: usize, flags: usize, data: usize) {
+pub fn trigger(scheme_id: SchemeId, event_id: usize, flags: usize, data: usize) {
     let registry = registry();
     let key = RegKey {
         scheme_id: scheme_id,

--- a/kernel/context/file.rs
+++ b/kernel/context/file.rs
@@ -1,11 +1,13 @@
 //! File struct
 
+use scheme::SchemeId;
+
 /// A file
 //TODO: Close on exec
 #[derive(Copy, Clone, Debug)]
 pub struct File {
     /// The scheme that this file refers to
-    pub scheme: usize,
+    pub scheme: SchemeId,
     /// The number the scheme uses to refer to this file
     pub number: usize,
     /// If events are on, this is the event ID

--- a/kernel/context/mod.rs
+++ b/kernel/context/mod.rs
@@ -1,11 +1,12 @@
 //! Context management
 use alloc::boxed::Box;
-use core::sync::atomic::{AtomicUsize, ATOMIC_USIZE_INIT, Ordering};
+use core::sync::atomic::Ordering;
 use spin::{Once, RwLock, RwLockReadGuard, RwLockWriteGuard};
 
 pub use self::context::{Context, Status};
 pub use self::list::ContextList;
 pub use self::switch::switch;
+pub use context::context::ContextId;
 
 /// Context struct
 mod context;
@@ -35,7 +36,7 @@ pub const CONTEXT_MAX_FILES: usize = 65536;
 static CONTEXTS: Once<RwLock<ContextList>> = Once::new();
 
 #[thread_local]
-static CONTEXT_ID: AtomicUsize = ATOMIC_USIZE_INIT;
+static CONTEXT_ID: context::AtomicContextId = context::AtomicContextId::default();
 
 pub fn init() {
     let mut contexts = contexts_mut();
@@ -69,6 +70,6 @@ pub fn contexts_mut() -> RwLockWriteGuard<'static, ContextList> {
     CONTEXTS.call_once(init_contexts).write()
 }
 
-pub fn context_id() -> usize {
+pub fn context_id() -> context::ContextId {
     CONTEXT_ID.load(Ordering::SeqCst)
 }

--- a/kernel/lib.rs
+++ b/kernel/lib.rs
@@ -43,6 +43,7 @@ extern crate goblin;
 extern crate spin;
 
 use core::sync::atomic::{AtomicUsize, ATOMIC_USIZE_INIT, Ordering};
+use scheme::FileHandle;
 
 #[macro_use]
 #[macro_export]
@@ -93,9 +94,9 @@ pub fn cpu_count() -> usize {
 pub extern fn userspace_init() {
     assert_eq!(syscall::chdir(b"initfs:bin"), Ok(0));
 
-    assert_eq!(syscall::open(b"debug:", 0), Ok(0));
-    assert_eq!(syscall::open(b"debug:", 0), Ok(1));
-    assert_eq!(syscall::open(b"debug:", 0), Ok(2));
+    assert_eq!(syscall::open(b"debug:", 0).map(FileHandle::into), Ok(0));
+    assert_eq!(syscall::open(b"debug:", 0).map(FileHandle::into), Ok(1));
+    assert_eq!(syscall::open(b"debug:", 0).map(FileHandle::into), Ok(2));
 
     syscall::exec(b"initfs:bin/init", &[]).expect("failed to execute initfs:init");
 

--- a/kernel/lib.rs
+++ b/kernel/lib.rs
@@ -44,13 +44,13 @@ extern crate spin;
 
 use core::sync::atomic::{AtomicUsize, ATOMIC_USIZE_INIT, Ordering};
 
-/// Context management
-pub mod context;
-
 #[macro_use]
+#[macro_export]
 /// Shared data structures
 pub mod common;
 
+/// Context management
+pub mod context;
 
 /// ELF file parsing
 #[cfg(all(not(test), target_arch = "x86_64"))]
@@ -105,7 +105,7 @@ pub extern fn userspace_init() {
 /// Allow exception handlers to send signal to arch-independant kernel
 #[no_mangle]
 pub extern fn ksignal(signal: usize) {
-    println!("SIGNAL {}, CPU {}, PID {}", signal, cpu_id(), context::context_id());
+    println!("SIGNAL {}, CPU {}, PID {:?}", signal, cpu_id(), context::context_id());
     {
         let contexts = context::contexts();
         if let Some(context_lock) = contexts.current() {

--- a/kernel/lib.rs
+++ b/kernel/lib.rs
@@ -47,6 +47,11 @@ use core::sync::atomic::{AtomicUsize, ATOMIC_USIZE_INIT, Ordering};
 /// Context management
 pub mod context;
 
+#[macro_use]
+/// Shared data structures
+pub mod common;
+
+
 /// ELF file parsing
 #[cfg(all(not(test), target_arch = "x86_64"))]
 pub mod elf;

--- a/kernel/scheme/debug.rs
+++ b/kernel/scheme/debug.rs
@@ -1,14 +1,15 @@
 use core::str;
-use core::sync::atomic::{AtomicUsize, Ordering, ATOMIC_USIZE_INIT};
+use core::sync::atomic::Ordering;
 use spin::Once;
 
 use context;
+use scheme::*;
 use sync::WaitQueue;
 use syscall::error::*;
 use syscall::flag::EVENT_READ;
 use syscall::scheme::Scheme;
 
-pub static DEBUG_SCHEME_ID: AtomicUsize = ATOMIC_USIZE_INIT;
+pub static DEBUG_SCHEME_ID: AtomicSchemeId = ATOMIC_SCHEMEID_INIT;
 
 /// Input queue
 static INPUT: Once<WaitQueue<u8>> = Once::new();

--- a/kernel/scheme/irq.rs
+++ b/kernel/scheme/irq.rs
@@ -1,14 +1,15 @@
 use core::{mem, str};
-use core::sync::atomic::{AtomicUsize, ATOMIC_USIZE_INIT, Ordering};
+use core::sync::atomic::Ordering;
 use spin::Mutex;
 
 use arch::interrupt::irq::acknowledge;
 use context;
+use scheme::{AtomicSchemeId, ATOMIC_SCHEMEID_INIT};
 use syscall::error::*;
 use syscall::flag::EVENT_READ;
 use syscall::scheme::Scheme;
 
-pub static IRQ_SCHEME_ID: AtomicUsize = ATOMIC_USIZE_INIT;
+pub static IRQ_SCHEME_ID: AtomicSchemeId = ATOMIC_SCHEMEID_INIT;
 
 /// IRQ queues
 static ACKS: Mutex<[usize; 16]> = Mutex::new([0; 16]);

--- a/kernel/scheme/mod.rs
+++ b/kernel/scheme/mod.rs
@@ -9,7 +9,7 @@
 use alloc::arc::Arc;
 use alloc::boxed::Box;
 use collections::BTreeMap;
-use core::sync::atomic::Ordering;
+use core::sync::atomic::{AtomicUsize, Ordering};
 use spin::{Once, RwLock, RwLockReadGuard, RwLockWriteGuard};
 
 use syscall::error::*;
@@ -62,10 +62,15 @@ pub mod zero;
 /// Limit on number of schemes
 pub const SCHEME_MAX_SCHEMES: usize = 65536;
 
+/// Unique identifier for a scheme.
+int_like!(SchemeId, AtomicSchemeId, usize, AtomicUsize);
+
+pub const ATOMIC_SCHEMEID_INIT: AtomicSchemeId = AtomicSchemeId::default();
+
 /// Scheme list type
 pub struct SchemeList {
-    map: BTreeMap<usize, Arc<Box<Scheme + Send + Sync>>>,
-    names: BTreeMap<Box<[u8]>, usize>,
+    map: BTreeMap<SchemeId, Arc<Box<Scheme + Send + Sync>>>,
+    names: BTreeMap<Box<[u8]>, SchemeId>,
     next_id: usize
 }
 
@@ -79,20 +84,20 @@ impl SchemeList {
         }
     }
 
-    pub fn iter(&self) -> ::collections::btree_map::Iter<usize, Arc<Box<Scheme + Send + Sync>>> {
+    pub fn iter(&self) -> ::collections::btree_map::Iter<SchemeId, Arc<Box<Scheme + Send + Sync>>> {
         self.map.iter()
     }
 
-    pub fn iter_name(&self) -> ::collections::btree_map::Iter<Box<[u8]>, usize> {
+    pub fn iter_name(&self) -> ::collections::btree_map::Iter<Box<[u8]>, SchemeId> {
         self.names.iter()
     }
 
     /// Get the nth scheme.
-    pub fn get(&self, id: usize) -> Option<&Arc<Box<Scheme + Send + Sync>>> {
+    pub fn get(&self, id: SchemeId) -> Option<&Arc<Box<Scheme + Send + Sync>>> {
         self.map.get(&id)
     }
 
-    pub fn get_name(&self, name: &[u8]) -> Option<(usize, &Arc<Box<Scheme + Send + Sync>>)> {
+    pub fn get_name(&self, name: &[u8]) -> Option<(SchemeId, &Arc<Box<Scheme + Send + Sync>>)> {
         if let Some(&id) = self.names.get(name) {
             self.get(id).map(|scheme| (id, scheme))
         } else {
@@ -101,7 +106,7 @@ impl SchemeList {
     }
 
     /// Create a new scheme.
-    pub fn insert(&mut self, name: Box<[u8]>, scheme: Arc<Box<Scheme + Send + Sync>>) -> Result<usize> {
+    pub fn insert(&mut self, name: Box<[u8]>, scheme: Arc<Box<Scheme + Send + Sync>>) -> Result<SchemeId> {
         if self.names.contains_key(&name) {
             return Err(Error::new(EEXIST));
         }
@@ -110,7 +115,7 @@ impl SchemeList {
             self.next_id = 1;
         }
 
-        while self.map.contains_key(&self.next_id) {
+        while self.map.contains_key(&SchemeId(self.next_id)) {
             self.next_id += 1;
         }
 
@@ -118,12 +123,11 @@ impl SchemeList {
             return Err(Error::new(EAGAIN));
         }
 
-        let id = self.next_id;
+        let id = SchemeId(self.next_id);
         self.next_id += 1;
 
         assert!(self.map.insert(id, scheme).is_none());
         assert!(self.names.insert(name, id).is_none());
-
         Ok(id)
     }
 }

--- a/kernel/scheme/mod.rs
+++ b/kernel/scheme/mod.rs
@@ -67,6 +67,10 @@ int_like!(SchemeId, AtomicSchemeId, usize, AtomicUsize);
 
 pub const ATOMIC_SCHEMEID_INIT: AtomicSchemeId = AtomicSchemeId::default();
 
+/// Unique identifier for a file descriptor.
+int_like!(FileHandle, AtomicFileHandle, usize, AtomicUsize);
+
+
 /// Scheme list type
 pub struct SchemeList {
     map: BTreeMap<SchemeId, Arc<Box<Scheme + Send + Sync>>>,

--- a/kernel/scheme/pipe.rs
+++ b/kernel/scheme/pipe.rs
@@ -2,6 +2,7 @@ use alloc::arc::{Arc, Weak};
 use collections::{BTreeMap, VecDeque};
 use core::sync::atomic::{AtomicUsize, ATOMIC_USIZE_INIT, Ordering};
 use spin::{Mutex, Once, RwLock, RwLockReadGuard, RwLockWriteGuard};
+use scheme::{AtomicSchemeId, ATOMIC_SCHEMEID_INIT};
 
 use sync::WaitCondition;
 use syscall::error::{Error, Result, EBADF, EPIPE};
@@ -9,7 +10,7 @@ use syscall::flag::O_NONBLOCK;
 use syscall::scheme::Scheme;
 
 /// Pipes list
-pub static PIPE_SCHEME_ID: AtomicUsize = ATOMIC_USIZE_INIT;
+pub static PIPE_SCHEME_ID: AtomicSchemeId = ATOMIC_SCHEMEID_INIT;
 static PIPE_NEXT_ID: AtomicUsize = ATOMIC_USIZE_INIT;
 static PIPES: Once<RwLock<(BTreeMap<usize, PipeRead>, BTreeMap<usize, PipeWrite>)>> = Once::new();
 

--- a/kernel/scheme/root.rs
+++ b/kernel/scheme/root.rs
@@ -1,16 +1,16 @@
 use alloc::arc::Arc;
 use alloc::boxed::Box;
 use collections::BTreeMap;
-use core::sync::atomic::{AtomicUsize, ATOMIC_USIZE_INIT, Ordering};
+use core::sync::atomic::{AtomicUsize, Ordering};
 use spin::RwLock;
 
 use context;
 use syscall::error::*;
 use syscall::scheme::Scheme;
-use scheme;
+use scheme::{self, AtomicSchemeId, ATOMIC_SCHEMEID_INIT};
 use scheme::user::{UserInner, UserScheme};
 
-pub static ROOT_SCHEME_ID: AtomicUsize = ATOMIC_USIZE_INIT;
+pub static ROOT_SCHEME_ID: AtomicSchemeId = ATOMIC_SCHEMEID_INIT;
 
 pub struct RootScheme {
     next_id: AtomicUsize,

--- a/kernel/scheme/sys/context.rs
+++ b/kernel/scheme/sys/context.rs
@@ -83,8 +83,8 @@ pub fn resource() -> Result<Vec<u8>> {
             let name = str::from_utf8(&name_bytes).unwrap_or("");
 
             string.push_str(&format!("{:<6}{:<6}{:<6}{:<6}{:<6}{:<6}{:<8}{}\n",
-                               context.id,
-                               context.ppid,
+                               context.id.into(),
+                               context.ppid.into(),
                                context.euid,
                                context.egid,
                                stat_string,

--- a/kernel/scheme/user.rs
+++ b/kernel/scheme/user.rs
@@ -53,7 +53,7 @@ impl UserInner {
 
         self.call_inner(Packet {
             id: self.next_id.fetch_add(1, Ordering::SeqCst),
-            pid: pid,
+            pid: pid.into(),
             uid: uid,
             gid: gid,
             a: a,
@@ -297,7 +297,7 @@ impl Scheme for UserScheme {
 
         inner.call_inner(Packet {
             id: id,
-            pid: pid,
+            pid: pid.into(),
             uid: uid,
             gid: gid,
             a: SYS_FMAP,

--- a/kernel/scheme/user.rs
+++ b/kernel/scheme/user.rs
@@ -1,6 +1,6 @@
 use alloc::arc::{Arc, Weak};
 use collections::BTreeMap;
-use core::sync::atomic::{AtomicUsize, AtomicU64, Ordering};
+use core::sync::atomic::{AtomicU64, Ordering};
 use core::{mem, slice, usize};
 use spin::{Mutex, RwLock};
 
@@ -10,6 +10,7 @@ use arch::paging::temporary_page::TemporaryPage;
 use context::{self, Context};
 use context::memory::Grant;
 use scheme::root::ROOT_SCHEME_ID;
+use scheme::{AtomicSchemeId, ATOMIC_SCHEMEID_INIT};
 use sync::{WaitQueue, WaitMap};
 use syscall::data::{Packet, Stat};
 use syscall::error::*;
@@ -20,7 +21,7 @@ use syscall::scheme::Scheme;
 pub struct UserInner {
     handle_id: usize,
     flags: usize,
-    pub scheme_id: AtomicUsize,
+    pub scheme_id: AtomicSchemeId,
     next_id: AtomicU64,
     context: Weak<RwLock<Context>>,
     todo: WaitQueue<Packet>,
@@ -33,7 +34,7 @@ impl UserInner {
         UserInner {
             handle_id: handle_id,
             flags: flags,
-            scheme_id: AtomicUsize::new(0),
+            scheme_id: ATOMIC_SCHEMEID_INIT,
             next_id: AtomicU64::new(1),
             context: context,
             todo: WaitQueue::new(),

--- a/kernel/syscall/fs.rs
+++ b/kernel/syscall/fs.rs
@@ -270,7 +270,7 @@ pub fn fevent(fd: usize, flags: usize) -> Result<usize> {
         let mut files = context.files.lock();
         let mut file = files.get_mut(fd).ok_or(Error::new(EBADF))?.ok_or(Error::new(EBADF))?;
         if let Some(event_id) = file.event.take() {
-            println!("{}: {}:{}: events already registered: {}", fd, file.scheme, file.number, event_id);
+            println!("{}: {:?}:{}: events already registered: {}", fd, file.scheme, file.number, event_id);
             context::event::unregister(fd, file.scheme, event_id);
         }
         file.clone()

--- a/kernel/syscall/fs.rs
+++ b/kernel/syscall/fs.rs
@@ -25,7 +25,7 @@ pub fn file_op(a: usize, fd: usize, c: usize, d: usize) -> Result<usize> {
 
     let mut packet = Packet {
         id: 0,
-        pid: pid,
+        pid: pid.into(),
         uid: uid,
         gid: gid,
         a: a,

--- a/kernel/syscall/fs.rs
+++ b/kernel/syscall/fs.rs
@@ -2,13 +2,13 @@
 use core::sync::atomic::Ordering;
 
 use context;
-use scheme;
+use scheme::{self, FileHandle};
 use syscall;
 use syscall::data::{Packet, Stat};
 use syscall::error::*;
 use syscall::flag::{MODE_DIR, MODE_FILE};
 
-pub fn file_op(a: usize, fd: usize, c: usize, d: usize) -> Result<usize> {
+pub fn file_op(a: usize, fd: FileHandle, c: usize, d: usize) -> Result<usize> {
     let (file, pid, uid, gid) = {
         let contexts = context::contexts();
         let context_lock = contexts.current().ok_or(Error::new(ESRCH))?;
@@ -39,11 +39,11 @@ pub fn file_op(a: usize, fd: usize, c: usize, d: usize) -> Result<usize> {
     Error::demux(packet.a)
 }
 
-pub fn file_op_slice(a: usize, fd: usize, slice: &[u8]) -> Result<usize> {
+pub fn file_op_slice(a: usize, fd: FileHandle, slice: &[u8]) -> Result<usize> {
     file_op(a, fd, slice.as_ptr() as usize, slice.len())
 }
 
-pub fn file_op_mut_slice(a: usize, fd: usize, slice: &mut [u8]) -> Result<usize> {
+pub fn file_op_mut_slice(a: usize, fd: FileHandle, slice: &mut [u8]) -> Result<usize> {
     file_op(a, fd, slice.as_mut_ptr() as usize, slice.len())
 }
 
@@ -81,7 +81,7 @@ pub fn getcwd(buf: &mut [u8]) -> Result<usize> {
 }
 
 /// Open syscall
-pub fn open(path: &[u8], flags: usize) -> Result<usize> {
+pub fn open(path: &[u8], flags: usize) -> Result<FileHandle> {
     let (path_canon, uid, gid) = {
         let contexts = context::contexts();
         let context_lock = contexts.current().ok_or(Error::new(ESRCH))?;
@@ -135,8 +135,8 @@ pub fn pipe2(fds: &mut [usize], flags: usize) -> Result<usize> {
             event: None,
         }).ok_or(Error::new(EMFILE))?;
 
-        fds[0] = read_fd;
-        fds[1] = write_fd;
+        fds[0] = read_fd.into();
+        fds[1] = write_fd.into();
 
         Ok(0)
     } else {
@@ -211,7 +211,7 @@ pub fn unlink(path: &[u8]) -> Result<usize> {
 }
 
 /// Close syscall
-pub fn close(fd: usize) -> Result<usize> {
+pub fn close(fd: FileHandle) -> Result<usize> {
     let file = {
         let contexts = context::contexts();
         let context_lock = contexts.current().ok_or(Error::new(ESRCH))?;
@@ -233,7 +233,7 @@ pub fn close(fd: usize) -> Result<usize> {
 }
 
 /// Duplicate file descriptor
-pub fn dup(fd: usize, buf: &[u8]) -> Result<usize> {
+pub fn dup(fd: FileHandle, buf: &[u8]) -> Result<FileHandle> {
     let file = {
         let contexts = context::contexts();
         let context_lock = contexts.current().ok_or(Error::new(ESRCH))?;
@@ -262,15 +262,15 @@ pub fn dup(fd: usize, buf: &[u8]) -> Result<usize> {
 }
 
 /// Register events for file
-pub fn fevent(fd: usize, flags: usize) -> Result<usize> {
+pub fn fevent(fd: FileHandle, flags: usize) -> Result<usize> {
     let file = {
         let contexts = context::contexts();
         let context_lock = contexts.current().ok_or(Error::new(ESRCH))?;
         let context = context_lock.read();
         let mut files = context.files.lock();
-        let mut file = files.get_mut(fd).ok_or(Error::new(EBADF))?.ok_or(Error::new(EBADF))?;
+        let mut file = files.get_mut(fd.into()).ok_or(Error::new(EBADF))?.ok_or(Error::new(EBADF))?;
         if let Some(event_id) = file.event.take() {
-            println!("{}: {:?}:{}: events already registered: {}", fd, file.scheme, file.number, event_id);
+            println!("{:?}: {:?}:{}: events already registered: {}", fd, file.scheme, file.number, event_id);
             context::event::unregister(fd, file.scheme, event_id);
         }
         file.clone()
@@ -287,7 +287,7 @@ pub fn fevent(fd: usize, flags: usize) -> Result<usize> {
         let context_lock = contexts.current().ok_or(Error::new(ESRCH))?;
         let context = context_lock.read();
         let mut files = context.files.lock();
-        let mut file = files.get_mut(fd).ok_or(Error::new(EBADF))?.ok_or(Error::new(EBADF))?;
+        let mut file = files.get_mut(fd.into()).ok_or(Error::new(EBADF))?.ok_or(Error::new(EBADF))?;
         file.event = Some(event_id);
     }
     context::event::register(fd, file.scheme, event_id);

--- a/kernel/syscall/mod.rs
+++ b/kernel/syscall/mod.rs
@@ -15,6 +15,7 @@ use self::error::{Error, Result, ENOSYS};
 use self::number::*;
 
 use context::ContextId;
+use scheme::FileHandle;
 
 /// Filesystem syscalls
 pub mod fs;
@@ -36,19 +37,22 @@ pub extern fn syscall(a: usize, b: usize, c: usize, d: usize, e: usize, f: usize
     #[inline(always)]
     fn inner(a: usize, b: usize, c: usize, d: usize, e: usize, f: usize, stack: usize) -> Result<usize> {
         match a & SYS_CLASS {
-            SYS_CLASS_FILE => match a & SYS_ARG {
-                SYS_ARG_SLICE => file_op_slice(a, b, validate_slice(c as *const u8, d)?),
-                SYS_ARG_MSLICE => file_op_mut_slice(a, b, validate_slice_mut(c as *mut u8, d)?),
-                _ => match a {
-                    SYS_CLOSE => close(b),
-                    SYS_DUP => dup(b, validate_slice(c as *const u8, d)?),
-                    SYS_FEVENT => fevent(b, c),
-                    SYS_FUNMAP => funmap(b),
-                    _ => file_op(a, b, c, d)
+            SYS_CLASS_FILE => {
+                let fd = FileHandle::from(b);
+                match a & SYS_ARG {
+                    SYS_ARG_SLICE => file_op_slice(a, fd, validate_slice(c as *const u8, d)?),
+                    SYS_ARG_MSLICE => file_op_mut_slice(a, fd, validate_slice_mut(c as *mut u8, d)?),
+                    _ => match a {
+                        SYS_CLOSE => close(fd),
+                        SYS_DUP => dup(fd, validate_slice(c as *const u8, d)?).map(FileHandle::into),
+                        SYS_FEVENT => fevent(fd, c),
+                        SYS_FUNMAP => funmap(b),
+                        _ => file_op(a, fd, c, d)
+                    }
                 }
             },
             SYS_CLASS_PATH => match a {
-                SYS_OPEN => open(validate_slice(b as *const u8, c)?, d),
+                SYS_OPEN => open(validate_slice(b as *const u8, c)?, d).map(FileHandle::into),
                 SYS_MKDIR => mkdir(validate_slice(b as *const u8, c)?, d as u16),
                 SYS_RMDIR => rmdir(validate_slice(b as *const u8, c)?),
                 SYS_UNLINK => unlink(validate_slice(b as *const u8, c)?),

--- a/kernel/syscall/mod.rs
+++ b/kernel/syscall/mod.rs
@@ -14,6 +14,8 @@ use self::data::TimeSpec;
 use self::error::{Error, Result, ENOSYS};
 use self::number::*;
 
+use context::ContextId;
+
 /// Filesystem syscalls
 pub mod fs;
 
@@ -54,13 +56,13 @@ pub extern fn syscall(a: usize, b: usize, c: usize, d: usize, e: usize, f: usize
             },
             _ => match a {
                 SYS_EXIT => exit(b),
-                SYS_WAITPID => waitpid(b, c, d),
+                SYS_WAITPID => waitpid(ContextId::from(b), c, d).map(ContextId::into),
                 SYS_EXECVE => exec(validate_slice(b as *const u8, c)?, validate_slice(d as *const [usize; 2], e)?),
                 SYS_CHDIR => chdir(validate_slice(b as *const u8, c)?),
-                SYS_GETPID => getpid(),
+                SYS_GETPID => getpid().map(ContextId::into),
                 SYS_BRK => brk(b),
                 SYS_IOPL => iopl(b),
-                SYS_CLONE => clone(b, stack),
+                SYS_CLONE => clone(b, stack).map(ContextId::into),
                 SYS_YIELD => sched_yield(),
                 SYS_NANOSLEEP => nanosleep(validate_slice(b as *const TimeSpec, 1).map(|req| &req[0])?, validate_slice_mut(c as *mut TimeSpec, 1).ok().map(|rem| &mut rem[0])),
                 SYS_GETCWD => getcwd(validate_slice_mut(b as *mut u8, c)?),

--- a/kernel/syscall/process.rs
+++ b/kernel/syscall/process.rs
@@ -1062,3 +1062,4 @@ pub fn waitpid(pid: usize, status_ptr: usize, flags: usize) -> Result<usize> {
         }
     }
 }
+


### PR DESCRIPTION
**Problem**: We're using `usize` for file descriptors, pids, scheme ids, ... It works, but it's also non-documenting and somewhat footgunish.

**Solution**: This PR introduces types `FileHandle`, `ContextId`, `SchemeId`, their atomic counterparts and a macro to generate similar types. At runtime, they behave exactly like `usize` (respectively `AtomicUsize`), but with added type-safety. This patch covers only the kernel.

**State**: Ready.

**Blockers**: Not strictly a blocker, but I expect to build upon this for https://github.com/redox-os/rfcs/pull/2.