### PR TITLE
fix pkgconfig darwin macports pkg in bootstrap.sh

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -95,7 +95,7 @@ osx_macports()
 
     install_macports_pkg "gcc49" "gcc-4.9"
     install_macports_pkg "nasm"
-    install_macports_pkg "pkg-config"
+    install_macports_pkg "pkgconfig"
     install_macports_pkg "osxfuse"
     install_macports_pkg "x86_64-elf-gcc"
 }


### PR DESCRIPTION
**Problem**: bootstrap.sh tried to download `pkg-config` when using Macports, even though it is called `pkgconfig` as found here: https://www.macports.org/ports.php?by=name&substr=pkgconfig

**Solution**: Replace `pkg-config` with `pkgconfig`.
