### PR TITLE
Upgrade rand to 0.3.15

### DIFF
--- a/drivers/e1000d/Cargo.toml
+++ b/drivers/e1000d/Cargo.toml
@@ -12,4 +12,4 @@ redox_syscall = { path = "../../syscall/" }
 
 [replace]
 "libc:0.2.17" = { git = "https://github.com/rust-lang/libc.git" }
-"rand:0.3.14" = { git = "https://github.com/rust-lang-nursery/rand.git" }
+"rand:0.3.15" = { git = "https://github.com/rust-lang-nursery/rand.git" }

--- a/drivers/rtl8168d/Cargo.toml
+++ b/drivers/rtl8168d/Cargo.toml
@@ -12,4 +12,4 @@ redox_syscall = { path = "../../syscall/" }
 
 [replace]
 "libc:0.2.17" = { git = "https://github.com/rust-lang/libc.git" }
-"rand:0.3.14" = { git = "https://github.com/rust-lang-nursery/rand.git" }
+"rand:0.3.15" = { git = "https://github.com/rust-lang-nursery/rand.git" }

--- a/schemes/ethernetd/Cargo.toml
+++ b/schemes/ethernetd/Cargo.toml
@@ -9,4 +9,4 @@ redox_syscall = { path = "../../syscall/" }
 
 [replace]
 "libc:0.2.17" = { git = "https://github.com/rust-lang/libc.git" }
-"rand:0.3.14" = { git = "https://github.com/rust-lang-nursery/rand.git" }
+"rand:0.3.15" = { git = "https://github.com/rust-lang-nursery/rand.git" }

--- a/schemes/ipd/Cargo.toml
+++ b/schemes/ipd/Cargo.toml
@@ -9,4 +9,4 @@ redox_syscall = { path = "../../syscall/" }
 
 [replace]
 "libc:0.2.17" = { git = "https://github.com/rust-lang/libc.git" }
-"rand:0.3.14" = { git = "https://github.com/rust-lang-nursery/rand.git" }
+"rand:0.3.15" = { git = "https://github.com/rust-lang-nursery/rand.git" }

--- a/schemes/tcpd/Cargo.toml
+++ b/schemes/tcpd/Cargo.toml
@@ -10,4 +10,4 @@ redox_syscall = { path = "../../syscall/" }
 
 [replace]
 "libc:0.2.17" = { git = "https://github.com/rust-lang/libc.git" }
-"rand:0.3.14" = { git = "https://github.com/rust-lang-nursery/rand.git" }
+"rand:0.3.15" = { git = "https://github.com/rust-lang-nursery/rand.git" }

--- a/schemes/udpd/Cargo.toml
+++ b/schemes/udpd/Cargo.toml
@@ -10,4 +10,4 @@ redox_syscall = { path = "../../syscall/" }
 
 [replace]
 "libc:0.2.17" = { git = "https://github.com/rust-lang/libc.git" }
-"rand:0.3.14" = { git = "https://github.com/rust-lang-nursery/rand.git" }
+"rand:0.3.15" = { git = "https://github.com/rust-lang-nursery/rand.git" }


### PR DESCRIPTION
After https://github.com/rust-lang-nursery/rand/commit/f2267c1d03b22349d7dedc1d823ebd115f820341, there is no `0.3.14` release for https://github.com/rust-lang-nursery/rand .

This commit fixes compilation of redox by upgrading rand's version to `0.3.15`.