### PR TITLE
Fix playbot typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Please make sure you use the **latest nightly** of `rustc` before building (for 
 
 The ecosystem and software Redox OS provides is listed below.
 
-| Name (lexiographic order)                                                   | Maintainer
+| Name (lexicographic order)                                                  | Maintainer
 |-----------------------------------------------------------------------------|---------------------------
 | [Ion (shell)](https://github.com/redox-os/ion)                              | [**@skylerberg**](https://github.com/skylerberg) & [**@jackpot51**](https://github.com/jackpot51)
 | [RANSID](https://github.com/redox-os/ransid)                                | [**@jackpot51**](https://github.com/jackpot51)

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ The ecosystem and software Redox OS provides is listed below.
 | [orbtk](https://github.com/redox-os/orbtk)                                  | [**@stratact**](https://github.com/stratact)
 | [orbutils](https://github.com/redox-os/orbutils)                            | [**@jackpot51**](https://github.com/jackpot51)
 | [pkgutils (current package manager)](https://github.com/redox-os/pkgutils)  | [**@jackpot51**](https://github.com/jackpot51)
-| [playbot (internal REPL bot)](https://github.com/redox-os/platbot)          | [**@ticki**](https://github.com/ticki)
+| [playbot (internal REPL bot)](https://github.com/redox-os/playbot)          | [**@ticki**](https://github.com/ticki)
 | [ralloc](https://github.com/redox-os/ralloc)                                | [**@ticki**](https://github.com/ticki)
 | [redoxfs (old filesystem)](https://github.com/redox-os/redoxfs)             | [**@jackpot51**](https://github.com/jackpot51)
 | [syscall](https://github.com/redox-os/syscall)                              | [**@jackpot51**](https://github.com/jackpot51)


### PR DESCRIPTION
**Problem**: I was exploring the project and a link in the README took me to a 404.

**Solution**: Fix a small typo in the link

**Changes introduced by this pull request**:

- Fix the link from `platbot` to `playbot`
- "lexicographic" has two "c"s in it

**Drawbacks**: None

**TODOs**: None

**Fixes**: I couldn't find any related issues.

**State**: ready

**Blocking/related**: None