### PR TITLE
Context: truncate files vector

### DIFF
--- a/kernel/context/context.rs
+++ b/kernel/context/context.rs
@@ -221,11 +221,21 @@ impl Context {
     }
 
     /// Remove a file
-    // TODO: adjust files vector to smaller size if possible
     pub fn remove_file(&self, i: FileHandle) -> Option<File> {
         let mut files = self.files.lock();
         if i.into() < files.len() {
-            files[i.into()].take()
+            let file = files[i.into()].take();
+            if file.is_some() {
+                for j in (0..files.len()).rev() {
+                    if files[j].is_some() {
+                        if j + 1 < files.len() {
+                            files.truncate(j + 1);
+                        }
+                        break;
+                    }
+                }
+            }
+            file
         } else {
             None
         }

--- a/kernel/context/context.rs
+++ b/kernel/context/context.rs
@@ -230,6 +230,7 @@ impl Context {
                     if files[j].is_some() {
                         if j + 1 < files.len() {
                             files.truncate(j + 1);
+                            files.shrink_to_fit();
                         }
                         break;
                     }

--- a/kernel/context/context.rs
+++ b/kernel/context/context.rs
@@ -230,7 +230,10 @@ impl Context {
                     if files[j].is_some() {
                         if j + 1 < files.len() {
                             files.truncate(j + 1);
-                            files.shrink_to_fit();
+                            if files.capacity() > j + 1 + 10 {
+                                // TODO: determine how much memory can be allocated but unused
+                                files.shrink_to_fit();
+                            }
                         }
                         break;
                     }


### PR DESCRIPTION
**Problem**: Size of context files vector is never reduced.

**Solution**: Adjust files vector to smallest size if possible.

**Changes introduced by this pull request**:

- Truncate files vector length if possible.
- Shrink files vector capacity if possible.

**Drawbacks**: If process opens and closes lots of files, this change may increase count of relocation.

**Fixes**: no related issue

**State**: ready
