### PR TITLE
Fedora bootstrap: Check if packages are already installed

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -224,8 +224,14 @@ fedora()
 			echo "Virtualbox already installed!"
 		fi
 	fi
-	echo "Installing necessary build tools..."
-	sudo dnf install gcc gcc-c++ glibc-devel.i686 nasm make fuse-devel
+	# Use rpm -q <package> to check if it's already installed
+	PKGS=$(for pkg in gcc gcc-c++ glibc-devel.i686 nasm make fuse-devel; do rpm -q $pkg > /dev/null; [ $? -ne 0 ] && echo $pkg; done)
+	# If the list of packages is not empty, install missing
+	COUNT=$(echo $PKGS | wc -w)
+	if [ $COUNT -ne 0 ]; then
+					echo "Installing necessary build tools..."
+					sudo dnf install $PKGS
+	fi
 }
 
 ###############################################################################


### PR DESCRIPTION
**Problem**:
The bootstrap script asks for sudo password even though there is nothing to be installed.

**Solution**:
Use `rpm` tool to check if the package is already installed and execute `dnf install` only if there is something to be installed.

**Changes introduced by this pull request**:
* Few extra lines in bootstrap

**State**: 
done
