### PR TITLE
Fix vesad text rendering

### DIFF
--- a/drivers/vesad/src/display.rs
+++ b/drivers/vesad/src/display.rs
@@ -136,7 +136,7 @@ impl Display {
                 for row in 0..16 {
                     let row_data = FONT[font_i + row];
                     for col in 0..8 {
-                        if (row_data >> (7 - col)) & 1 == 1 {
+                        if (row_data >> (8 - col)) & 1 == 1 {
                             unsafe { *((dst + col * 4) as *mut u32)  = color; }
                         }
                     }


### PR DESCRIPTION
This pull request fixes a small bug in the bitmapped font rendering routine which caused the glyphs to be rendered incorrectly. It was really visible around the block drawing characters.

Screenshots:
[Before the fix](http://i.imgur.com/mqrJnth.jpg) - [After](http://i.imgur.com/AgTEHvP.jpg)