### PR TITLE
Force flush of tables

### DIFF
--- a/arch/x86_64/src/acpi/dmar/mod.rs
+++ b/arch/x86_64/src/acpi/dmar/mod.rs
@@ -59,7 +59,8 @@ pub struct DmarDrhd {
 
 impl DmarDrhd {
     pub fn get(&self, active_table: &mut ActivePageTable) -> &'static mut Drhd {
-        active_table.identity_map(Frame::containing_address(PhysicalAddress::new(self.base as usize)), entry::PRESENT | entry::WRITABLE | entry::NO_EXECUTE);
+        let result = active_table.identity_map(Frame::containing_address(PhysicalAddress::new(self.base as usize)), entry::PRESENT | entry::WRITABLE | entry::NO_EXECUTE);
+        result.flush(active_table);
         unsafe { &mut *(self.base as *mut Drhd) }
     }
 }

--- a/arch/x86_64/src/device/local_apic.rs
+++ b/arch/x86_64/src/device/local_apic.rs
@@ -32,7 +32,8 @@ impl LocalApic {
         if ! self.x2 {
             let page = Page::containing_address(VirtualAddress::new(self.address));
             let frame = Frame::containing_address(PhysicalAddress::new(self.address - ::KERNEL_OFFSET));
-            active_table.map_to(page, frame, entry::PRESENT | entry::WRITABLE | entry::NO_EXECUTE);
+            let result = active_table.map_to(page, frame, entry::PRESENT | entry::WRITABLE | entry::NO_EXECUTE);
+            result.flush(active_table);
         }
 
         self.init_ap();

--- a/arch/x86_64/src/lib.rs
+++ b/arch/x86_64/src/lib.rs
@@ -1,5 +1,6 @@
 //! Architecture support for x86_64
 
+#![deny(unused_must_use)]
 #![feature(asm)]
 #![feature(concat_idents)]
 #![feature(const_fn)]

--- a/arch/x86_64/src/paging/temporary_page.rs
+++ b/arch/x86_64/src/paging/temporary_page.rs
@@ -26,7 +26,8 @@ impl TemporaryPage {
     /// Returns the start address of the temporary page.
     pub fn map(&mut self, frame: Frame, flags: EntryFlags, active_table: &mut ActivePageTable) -> VirtualAddress {
         assert!(active_table.translate_page(self.page).is_none(), "temporary page is already mapped");
-        active_table.map_to(self.page, frame, flags);
+        let result = active_table.map_to(self.page, frame, flags);
+        result.flush(active_table);
         self.page.start_address()
     }
 
@@ -38,6 +39,7 @@ impl TemporaryPage {
 
     /// Unmaps the temporary page in the active table.
     pub fn unmap(&mut self, active_table: &mut ActivePageTable) {
-        active_table.unmap(self.page)
+        let result = active_table.unmap(self.page);
+        result.flush(active_table);
     }
 }


### PR DESCRIPTION
This uses a must_use struct to ensure that flushes of the table happen, or that places where they do not happen are explicitely shown.
