### PR TITLE
fix bootstrap issue on archlinux 64 bit

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -156,7 +156,11 @@ archLinux()
 	if [ "$1" == "qemu" ]; then
 		if [ -z "$(which qemu-system-i386)" ]; then
 			echo "Installing QEMU..."
-			sudo pacman -S qemu
+			if [ "$(uname -m)" == "x86_64" ]; then
+				sudo pacman -S qemu-arch-extra
+			else
+				sudo pacman -S qemu
+			fi
 		else
 			echo "QEMU already installed!"
 		fi


### PR DESCRIPTION
On Archlinux 64 bit, `qemu-system-i386' is in "qemu-arch-extra" package instead of "qemu"