### PR TITLE
Change way to generate initfs for kernel

### DIFF
--- a/mk/config.mk
+++ b/mk/config.mk
@@ -40,6 +40,7 @@ KCARGOFLAGS=--target $(KTARGET) --release -- -C soft-float
 # Userspace variables
 export TARGET=$(ARCH)-unknown-redox
 BUILD=build/userspace
+export INITFS_FOLDER=$(ROOT)/initfs
 RUSTC=./rustc.sh
 RUSTDOC=./rustdoc.sh
 CARGO=RUSTC="$(RUSTC)" RUSTDOC="$(RUSTDOC)" CARGO_INCREMENTAL=1 cargo

--- a/mk/initfs.mk
+++ b/mk/initfs.mk
@@ -7,18 +7,6 @@ $(BUILD)/initfs.rs: \
 		initfs/bin/redoxfs \
 		initfs/bin/vesad \
 		initfs/etc/**
-	echo 'use collections::BTreeMap;' > $@
-	echo 'pub fn gen() -> BTreeMap<&'"'"'static [u8], (&'"'"'static [u8], bool)> {' >> $@
-	echo '    let mut files: BTreeMap<&'"'"'static [u8], (&'"'"'static [u8], bool)> = BTreeMap::new();' >> $@
-	for folder in `find initfs -type d | sort`; do \
-		name=$$(echo $$folder | sed 's/initfs//' | cut -d '/' -f2-) ; \
-		$(ECHO) -n '    files.insert(b"'$$name'", (b"' >> $@ ; \
-		ls -1 $$folder | sort | awk 'NR > 1 {printf("\\n")} {printf("%s", $$0)}' >> $@ ; \
-		echo '", true));' >> $@ ; \
-	done
-	find initfs -type f -o -type l | cut -d '/' -f2- | sort | awk '{printf("    files.insert(b\"%s\", (include_bytes!(\"../../initfs/%s\"), false));\n", $$0, $$0)}' >> $@
-	echo '    files' >> $@
-	echo '}' >> $@
 
 initfs/bin/%: programs/%/Cargo.toml programs/%/src/** $(BUILD)/libstd.rlib
 	mkdir -p initfs/bin


### PR DESCRIPTION
this change should be merged along with corresponding PR in kernel (https://github.com/redox-os/kernel/pull/3)

**Problem**: [describe the problem you try to solve with this PR.]
Decouple kernel from whole redox. It can be compiled on its own. Changing initfs folder location does not require modifications in kernel

**Solution**: [describe carefully what you change by this PR.]
build scripts are changed to send initfs folder as a parameter ( env var: INITFS_FOLDER) to kernel build.rs script

**Changes introduced by this pull request**:
As described above

**Drawbacks**: [if any, describe the drawbacks of this pull request.]
has to be merged along with change in kernel repo

**TODOs**: [what is not done yet.]
N/A

**Fixes**: [what issues this fixes.]
N/A

**State**: [the state of this PR, e.g. WIP, ready, etc.]
N/A

**Blocking/related**: [issues or PRs blocking or being related to this issue.]
N/A

**Other**: [optional: for other relevant information that should be known or cannot be described in the other fields.]
N/A

------

_The above template is not necessary for smaller PRs._
