### PR TITLE
Ignore exit code from which in install_macos_pkg

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -26,7 +26,7 @@ install_macos_pkg()
         BIN_NAME=$PKG_NAME
     fi
 
-    BIN_LOCATION=$(which $BIN_NAME)
+    BIN_LOCATION=$(which $BIN_NAME || true)
     if [ -z "$BIN_LOCATION" ]; then
         echo "$PKG_MANAGER install $PKG_NAME"
         $PKG_MANAGER install "$PKG_NAME"


### PR DESCRIPTION
On my OS X El Capitan machine `which` returns 1 if it can't find the binary. This kills the bootstrap script at the crucial moment when it detects that something needs to be installed. This change ignores unsuccessful exit codes from `which`. The man page for my `which` speaks of a `-s` switch that could be used instead of the `if [ -z`, but I don't know how portable this is.

This fixes Issue #850.