### PR TITLE
Set $(RUSTC) to full path

### DIFF
--- a/mk/config.mk
+++ b/mk/config.mk
@@ -41,7 +41,7 @@ KCARGOFLAGS=--target $(KTARGET) --release -- -C soft-float
 export TARGET=$(ARCH)-unknown-redox
 BUILD=build/userspace
 export INITFS_FOLDER=$(ROOT)/initfs
-RUSTC=./rustc.sh
+RUSTC=$(PWD)/rustc.sh
 RUSTDOC=./rustdoc.sh
 CARGO=RUSTC="$(RUSTC)" RUSTDOC="$(RUSTDOC)" CARGO_INCREMENTAL=1 cargo
 CARGOFLAGS=--target $(TARGET) --release -- -C codegen-units=`$(NPROC)`


### PR DESCRIPTION
This fixes builds of crates that use `rustc_version` to test the Rust version in their build scripts.