### PR TITLE
Remove erroneous -b option from bootstrap.sh help

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -350,7 +350,7 @@ usage()
 	echo "   -d             Only install the dependencies, skip boot step"
 	echo "EXAMPLES:"
 	echo
-	echo "./bootstrap.sh -b buddy -e qemu"
+	echo "./bootstrap.sh -e qemu"
 	exit
 }
 


### PR DESCRIPTION
The help also tells you to use './bootstrap.sh' but the file wasn't +x in
the repo, so I've set that +x as well.

This closes issue #852