### PR TITLE
add ln command to coreutils.mk

### DIFF
--- a/mk/userspace/coreutils.mk
+++ b/mk/userspace/coreutils.mk
@@ -15,6 +15,7 @@ coreutils: \
 	filesystem/bin/free \
 	filesystem/bin/head \
 	filesystem/bin/kill \
+	filesystem/bin/ln \
 	filesystem/bin/ls \
 	filesystem/bin/mkdir \
 	filesystem/bin/mv \


### PR DESCRIPTION
**Problem**: links are not fully implemented by fs

**Solution**: app will fail with proper error

**Changes introduced by this pull request**:

- auto install ln command to /bin ( mk/userspace/coreutils.mk)

main changes merged by <Add ln command to coreutils #139> to coreutils repo

