### PR TITLE
Don't install fuse if it's there already

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -163,7 +163,7 @@ archLinux()
 	fi
 
 	echo "Installing fuse..."
-	sudo pacman -S fuse
+	sudo pacman -S --needed fuse
 }
 
 ###############################################################################


### PR DESCRIPTION
Just adds '--needed' so fuse isn't re-installed
