### PR TITLE
Allow entering redox version in issue template.

### DIFF
--- a/.github/ISSUE_TEMPLATE
+++ b/.github/ISSUE_TEMPLATE
@@ -4,7 +4,8 @@
 
 **Actual behavior**: [describe the actual behavior, which is presented through the repro.].
 
-**Build information**: [output of `rustc -V`, `git rev-parse HEAD`, `qemu-i386 -version`, `uname -a`, etc.]
+**Build information**: [only when using a self build version: output of `rustc -V`, `git rev-parse HEAD` `qemu-i386 -version`, `uname -a`, etc.]
+**Redox release**: [only when using a prebuild version: redox version]
 
 **Blocking/related**: [issues or PRs blocking or being related to this issue.]
 


### PR DESCRIPTION
**Problem**: Issue template build information is only applicable to self build redox versions.

**Solution**: Make it clear that build information is only for self build versions and add field for prebuild redox version.

**TODOs**: None

**Fixes**: None

**State**: ready

**Related**: #889
