### PR TITLE
Use absolute paths to virtualbox options

### DIFF
--- a/mk/virtualbox.mk
+++ b/mk/virtualbox.mk
@@ -1,3 +1,4 @@
+BUILDDIR = $(abspath $(dir $(firstword $(MAKEFILE_LIST))))/build
 virtualbox: build/harddrive.bin
 	echo "Delete VM"
 	-$(VBM) unregistervm Redox --delete; \
@@ -22,10 +23,10 @@ virtualbox: build/harddrive.bin
 		$(VBM) modifyvm Redox --nictype1 82540EM; \
 		$(VBM) modifyvm Redox --cableconnected1 on; \
 		$(VBM) modifyvm Redox --nictrace1 on; \
-		$(VBM) modifyvm Redox --nictracefile1 build/network.pcap; \
+		$(VBM) modifyvm Redox --nictracefile1 "$(BUILDDIR)/redox_network.pcap"; \
 	fi
 	$(VBM) modifyvm Redox --uart1 0x3F8 4
-	$(VBM) modifyvm Redox --uartmode1 file build/serial.log
+	$(VBM) modifyvm Redox --uartmode1 file "$(BUILDDIR)/redox_serial.log"
 	$(VBM) modifyvm Redox --usb off # on
 	$(VBM) modifyvm Redox --keyboard ps2
 	$(VBM) modifyvm Redox --mouse ps2


### PR DESCRIPTION
According to the (virtualbox docs)[https://www.virtualbox.org/manual/ch08.html#vboxmanage-modifyvm] the file paths to `--uartmode` and `--nictracefile` must be absolute. `make virtualbox` fails for me without this patch.