### PR TITLE
Make easy targets section more readable.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,21 +61,21 @@ News and updates for Redox are posted at [redox-os.org/news](https://redox-os.or
 
 ### <a name="easy-targets"> Low-Hanging Fruit - Easy Targets for Newbies </a>
 
-* If you're not fluent in Rust:
+#### If you're not fluent in Rust:
 
  * Writing documentation
  * Using/testing Redox, filing issues for bugs and needed features
  * Web development ([Redox website, separate repo](https://github.com/redox-os/website))
  * Writing unit tests (may require minimal knowledge of rust)
 
-* If you are fluent in Rust, but not OS Development:
+#### If you are fluent in Rust, but not OS Development:
 
  * Apps development
  * Shell ([Ion](https://github.com/redox-os/ion)) development
  * Package manager ([Magnet](https://github.com/redox-os/magnet)) development
  * Other high-level code tasks
 
-* If you are fluent in Rust, and have experience with OS Dev:
+#### If you are fluent in Rust, and have experience with OS Dev:
 
  * Familiarize yourself with the repository and codebase
  * Grep for `TODO`, `FIXME`, `BUG`, `UNOPTIMIZED`, `REWRITEME`, `DOCME`, and `PRETTYFYME` and fix the code you find.


### PR DESCRIPTION


**Problem**: [describe the problem you try to solve with this PR.]
For me (and as I think, for many others) it was very difficult to distinguish tasks that are proposed for Rust fluent developers (as well as OS and non-OS experts) and Rust newbies.

**Solution**: [describe carefully what you change by this PR.]
Add subsections for each type of developers.

**Changes introduced by this pull request**:
- Added subsections in "Low-hanging fruit" section.
