### PR TITLE
Make build/filesystem.bin and build/initfs.tag targets .PHONY

### DIFF
--- a/mk/filesystem.mk
+++ b/mk/filesystem.mk
@@ -40,3 +40,5 @@ unmount: FORCE
 	sync
 	-$(FUMOUNT) build/filesystem/ || true
 	rm -rf build/filesystem/
+
+.PHONY: build/filesystem.bin

--- a/mk/initfs.mk
+++ b/mk/initfs.mk
@@ -1,3 +1,5 @@
 build/initfs.tag: initfs.toml
 	cargo run --manifest-path installer/Cargo.toml -- --cookbook=cookbook $<
 	touch $@
+
+.PHONY: build/initfs.tag


### PR DESCRIPTION
This needs to be run to check for updates in the cookbook.

A more ideal solution would only rebuild these files if the cookbook updated a package; I don't know how best to implement that though.