### PR TITLE
Change the default mac to a valid value.

### DIFF
--- a/filesystem.toml
+++ b/filesystem.toml
@@ -94,7 +94,7 @@ data = "255.255.255.0"
 
 [[files]]
 path = "/etc/net/mac"
-data = "00.00.00.00.00.00"
+data = "54-52-00-ab-cd-ef"
 
 [[files]]
 path = "/etc/pkg.d/50_redox"


### PR DESCRIPTION
**Problem**: Since NIC MAC addresses can't be used in ethernetd at the time, Redox uses the address from `/etc/net/mac`, which is all zero. It works with qemu's user network, but doesn't work with qemu's bridged network, because the Linux network stack on the other end doesn't consider all-zero MAC addresses valid.

**Solution**: Change the default MAC address to some reasonable value.

**Changes introduced by this pull request**:
- The default value of `/etc/net/mac` has been changed to 54-52-00-ab-cd-ef.

**State**: Redox runs in bridged network mode and is able to interact with the host machine directly via network.

**Other**: The 54:52:00 prefix is reserved for Linux KVM use: http://www.coffer.com/mac_find/?string=5452 .