### PR TITLE
Add 'pkg-config' to list of Ubuntu packages

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -174,7 +174,7 @@ ubuntu()
 	echo "Updating system..."
 	sudo "$2" update
 	echo "Installing required packages..."
-	sudo "$2" install build-essential libc6-dev-i386 nasm curl file git libfuse-dev fuse
+	sudo "$2" install build-essential libc6-dev-i386 nasm curl file git libfuse-dev fuse pkg-config
 	if [ "$1" == "qemu" ]; then
 		if [ -z "$(which qemu-system-x86_64)" ]; then
 			echo "Installing QEMU..."


### PR DESCRIPTION
Currently running `make` will fail on
```
cargo run --manifest-path installer/redoxfs/Cargo.toml --release --bin redoxfs-mkfs build/filesystem.bin.partial
```
as this command will call into `pkg-config --libs --cflags fuse` (which clearly depends on `pkg-config`. This package did not get installed by `bootstrap.sh` inside a Xenial Vagrant Box; one figures its better to be explicit about this dependency.