### PR TITLE
Use Docker to distribute the build system

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,31 @@
+FROM ubuntu:17.04
+
+ENV REDOX_TOOLCHAIN_APT http://static.redox-os.org/toolchain/apt/
+ENV SRC_PATH /src
+ENV CARGO_HOME /cargo
+ENV RUSTUP_HOME /rustup
+ENV PATH $CARGO_HOME/bin:$PATH
+
+RUN apt-get update \
+      && apt-get install -y git gosu gcc fuse nasm qemu-utils pkg-config \
+         libfuse-dev make curl file sudo apt-transport-https \
+      && mkdir -p $CARGO_HOME \
+      && mkdir -p $RUSTUP_HOME \
+      && curl https://sh.rustup.rs > sh.rustup.rs \
+      && sh sh.rustup.rs -y \
+      && rustup update \
+      && rustup component add rust-src \
+      && rustup default nightly \
+      && echo "deb $REDOX_TOOLCHAIN_APT /" >> /etc/apt/sources.list.d/redox.list \
+      && apt-get update \
+      && apt-get install -y --force-yes x86-64-elf-redox-newlib x86-64-elf-redox-binutils x86-64-elf-redox-gcc \
+      && cargo install xargo \
+      && mkdir -p "$SRC_PATH"
+
+WORKDIR $SRC_PATH
+
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Add local user
+# Either use the LOCAL_USER_ID if passed in at runtime or
+# fallback
+
+USER_ID=${LOCAL_USER_ID:-9001}
+
+echo "Starting with UID : $USER_ID "
+echo "CARGO_HOME is $CARGO_HOME"
+echo "RUSTUP_HOME is $RUSTUP_HOME"
+useradd --shell /bin/bash -u $USER_ID -o -c "" -m user
+export HOME=/home/user
+chown user:user -R $CARGO_HOME
+chown user:user -R $RUSTUP_HOME
+
+exec gosu user:user "$@"


### PR DESCRIPTION
**Problem**: Redox's build system is hard to setup and maintain, and changes regularly.

**Solution**: Use Docker to build self-contained images with all the tools needed and then use them on a local checkout of Redox to build disk images.

**Changes introduced by this pull request**:
- `Dockerfile` and `entrypoint.sh` has been added.

**How to use**:
1. To build an image, run `docker build -t redox . ` in the `docker` directory. This will create a new image called `redox` in the local image repository. You can rebuild this image every time you need to update the toolchain.
2. Instead of `make all` call ``docker run --cap-add MKNOD --cap-add SYS_ADMIN --device /dev/fuse -e LOCAL_USER_ID=`id -u` -v `pwd`:/src --rm redox make all`` . To clarify, `--cap-add MKNOD --cap-add SYS_ADMIN --device /dev/fuse` is required to use `fuse` inside the container, ``-e LOCAL_USER_ID=`id -u` `` sets the `LOCAL_USER_ID` variable to the current uid so `entrypoint.sh` can setup a non-root user inside the container to run commands as, ``-v `pwd`:/src`` binds the currend directory as `/src` inside the container, `--rm` removes the container after it's finished, `redox` is the name of the image to run and `make all` is the command to run inside the container.
3. The container can be run with an interactive shell instead with ``docker run --cap-add MKNOD --cap-add SYS_ADMIN --device /dev/fuse -e LOCAL_USER_ID=`id -u` -v `pwd`:/src --rm -it redox bash`` .

**How I propose we use it**:
- The best way to use it is to setup the official dockerhub repository, `redox-os/toolchain` for example, so a user can skip step 1 above and just call ``docker run --cap-add MKNOD --cap-add SYS_ADMIN --device /dev/fuse -e LOCAL_USER_ID=`id -u` -v `pwd`:/src --rm redox-os/toolchain make all``, which would automatically downlad the image and run it as described above. The image will be saved in the local repository until it's updated in the hub. 
- Dockerhub can be configured to automatically rebuild images from a Dockerfile in a github repository on each push: https://docs.docker.com/docker-hub/builds/ .
- After it's done we can change the Makefile to hide that scary long line behind something like `make all docker=1`. 
- This setup will allow the maintainer to change the configuration of the build system whenever and however he likes without breaking users's build setups.

**TODO**:
- I have no idea if it works on *BSD and macOS, options I've used to run `fuse` inside a container might not work.



 