### PR TITLE
Tweaks to Makefiles to be able to build the kernel on macOS again.

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -93,6 +93,8 @@ osx_macports()
         install_macports_pkg "virtualbox"
     fi
 
+    install_macports_pkg "coreutils"
+    install_macports_pkg "findutils"
     install_macports_pkg "gcc49" "gcc-4.9"
     install_macports_pkg "nasm"
     install_macports_pkg "pkgconfig"
@@ -120,6 +122,8 @@ osx_homebrew()
         install_brew_pkg "virtualbox"
     fi
 
+    install_macports_pkg "coreutils"
+    install_macports_pkg "findutils"
     install_brew_pkg "gcc49" "gcc-4.9"
     install_brew_pkg "nasm"
     install_brew_pkg "pkg-config"
@@ -298,7 +302,7 @@ gentoo()
 solus()
 {
 	echo "Detected SolusOS"
-	
+
 	if [ "$1" == "qemu" ]; then
 		if [ -z "$(which qemu-system-x86_64)" ]; then
 			sudo eopkg it qemu
@@ -314,7 +318,7 @@ solus()
 			echo "Virtualbox already installed!"
 		fi
 	fi
-	
+
 	echo "Installing necessary build tools..."
 	#if guards are not necessary with eopkg since it does nothing if latest version is already installed
 	sudo eopkg it fuse-devel git gcc g++ libgcc-32bit libstdc++-32bit nasm make

--- a/mk/kernel.mk
+++ b/mk/kernel.mk
@@ -1,5 +1,10 @@
 build/libkernel.a: kernel/Cargo.toml kernel/src/* kernel/src/*/* kernel/src/*/*/* build/initfs.tag
+# Temporary fix for https://github.com/redox-os/redox/issues/963 allowing to build on macOS
+ifeq ($(UNAME),Darwin)
+	cd kernel && CC=$(ARCH)-elf-gcc AR=$(ARCH)-elf-ar CFLAGS=-ffreestanding xargo rustc --lib --target $(KTARGET) --release -- -C soft-float --emit link=../$@
+else
 	cd kernel && xargo rustc --lib --target $(KTARGET) --release -- -C soft-float --emit link=../$@
+endif
 
 build/libkernel_live.a: kernel/Cargo.toml kernel/src/* kernel/src/*/* kernel/src/*/*/* build/initfs.tag build/filesystem.bin
 	cd kernel && FILESYSTEM="$(PWD)/build/filesystem.bin" xargo rustc --lib --features live --target $(KTARGET) --release -- -C soft-float --emit link=../$@


### PR DESCRIPTION
**Problem**: 

The kernel can't be built (without fiddling with env vars and stuff which) due to one of `raw-cpuid` C dependencies being compiled as a Mach-O object file by the macOS toolchain and also the cookbook scripts assume GNU utilities. This may be a show stopper for newcomers on macOS.

**Solution**: 

- Force using the macOS Redox toolchain compiler and archiver in order
to generate a proper ELF file when building the 'raw-cpuid'
crate C code.

- Add the `findutils` and `coreutils` Homebrew/MacPorts
packages to the bootstrap script in order to setup the proper
environment for the cookbook scripts (as they assume GNU tools).
This should be temporary until the cookbook scripts get migrated
to Rust. `findutils` contains `gfind` AKA GNU find. And `coreutils` contain
`stat` which may look overkill but I guess after this we can safely assume
that cookbook scripts will have GNU coreutils available making them simpler.

**Changes introduced by this pull request**:

- Force CC and AR in kernel buidling/linking on macOS.
- Add the `findutils` and `coreutils` Homebrew/MacPorts
packages to the bootstrap script.

**Fixes**: https://github.com/redox-os/redox/issues/963

**State**: [the state of this PR, e.g. WIP, ready, etc.]

**Blocking/related**: I'm gonna link the cookbook PR soon.