### PR TITLE
Fixing copy-paste error on boostrap scripts for macOS.

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -122,8 +122,8 @@ osx_homebrew()
         install_brew_pkg "virtualbox"
     fi
 
-    install_macports_pkg "coreutils"
-    install_macports_pkg "findutils"
+    install_brew_pkg "coreutils"
+    install_brew_pkg "findutils"
     install_brew_pkg "gcc49" "gcc-4.9"
     install_brew_pkg "nasm"
     install_brew_pkg "pkg-config"


### PR DESCRIPTION
**Problem**: 

Mistaken MacPorts installation code on Homebrew section. Breaks the macOS Homebrew based part of the bootstrap script.

At some point I miss-copied-pasted when extending the bootstrap script to have `findutils` and `coreutils` on macOS. I realised that when trying to make a setup form scratch on my machine to test everything again. 

**Solution**:

Install Homebrew packages instead of MacPorts packages on the brew section.

**Changes introduced by this pull request**:

- Replaced two calls to `install_macports_pkg` to `install_brew_pkg`.

**State**: Ready