### PR TITLE
bootstrap.sh: Use correct FUSE package for SUSE

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -262,7 +262,7 @@ suse()
 		fi
 	fi
 	echo "Installing necessary build tools..."
-	sudo zypper install gcc gcc-c++ glibc-devel-32bit nasm make libfuse
+	sudo zypper install gcc gcc-c++ glibc-devel-32bit nasm make fuse-devel
 }
 
 ##############################################################################


### PR DESCRIPTION
**Problem**: libfuse does not exist on Tumbleweed and Leap 42.3, also the devel package is required.

**Solution**: Use fuse-devel, same as Fedora
