### PR TITLE
Build docker container with ready to use user env

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,35 +1,44 @@
 FROM ubuntu:17.04
 
 ENV REDOX_TOOLCHAIN_APT http://static.redox-os.org/toolchain/apt/
-ENV SRC_PATH /src
-ENV CARGO_HOME /cargo
-ENV RUSTUP_HOME /rustup
-ENV PATH $CARGO_HOME/bin:$PATH
 
-RUN apt-get update \
+ENV USER user
+ARG LOCAL_UID=local
+ARG LOCAL_GID=local
+ENV BUILD_UID=${LOCAL_UID:-9001}
+ENV BUILD_GID=${LOCAL_GID:-9001}
+
+RUN   apt-get update \
       && apt-get install -y git gosu gcc fuse nasm qemu-utils pkg-config \
-         libfuse-dev make curl file sudo apt-transport-https autoconf flex \
-         bison texinfo \
-      && mkdir -p $CARGO_HOME \
-      && mkdir -p $RUSTUP_HOME \
-      && curl https://sh.rustup.rs > sh.rustup.rs \
+             libfuse-dev make curl file sudo apt-transport-https autoconf flex \
+             bison texinfo \
+      && echo "deb $REDOX_TOOLCHAIN_APT /" >> /etc/apt/sources.list.d/redox.list \
+      && apt-get update -o Dir::Etc::sourcelist="redox.list" \
+      && apt-get install -y --force-yes x86-64-elf-redox-newlib x86-64-elf-redox-binutils x86-64-elf-redox-gcc \
+      && groupadd -g $BUILD_GID user \
+      && useradd --shell /bin/bash -u $BUILD_UID -g $BUILD_GID -o -c "" -m $USER \
+      && echo "$USER ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/user-no-sudo-password
+
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+USER $USER
+ENV HOME /home/$USER
+ENV PATH $HOME/.cargo/bin:$PATH
+ENV SRC_PATH $HOME/src
+WORKDIR $HOME
+RUN   curl https://sh.rustup.rs > sh.rustup.rs \
       && sh sh.rustup.rs -y \
       && rustup update \
       && rustup component add rust-src \
       && rustup default nightly \
-      && echo "deb $REDOX_TOOLCHAIN_APT /" >> /etc/apt/sources.list.d/redox.list \
-      && apt-get update \
-      && apt-get install -y --force-yes x86-64-elf-redox-newlib x86-64-elf-redox-binutils x86-64-elf-redox-gcc \
       && curl -O https://ftp.gnu.org/gnu/automake/automake-1.15.1.tar.gz \
-      && tar -xvpf automake-1.15.1.tar.gz; cd automake-1.15.1; ./configure; make; make install; cd .. \
+      && tar -xvpf automake-1.15.1.tar.gz; cd automake-1.15.1; ./configure; make; sudo make install; cd .. \
       && cargo install xargo \
       && cargo install cargo-config \
-      && mkdir -p "$SRC_PATH"
+      && mkdir -p $SRC_PATH
 
 WORKDIR $SRC_PATH
-
-COPY entrypoint.sh /usr/local/bin/entrypoint.sh
-
-RUN chmod +x /usr/local/bin/entrypoint.sh
+USER root
 
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -4,11 +4,13 @@
 
 ```shell
 git clone https://github.com/redox-os/redox.git ; cd redox #1
-make pull #2
-docker build -t redox docker/ #3
+git pull --rebase --recurse-submodules && git submodule sync \
+    && git submodule update --recursive --init #2
+docker build --build-arg LOCAL_UID="$(id -u)" --build-arg LOCAL_GID="$(id -g)" \
+    -t redox docker/ #3
 docker run --cap-add MKNOD --cap-add SYS_ADMIN \
-    --device /dev/fuse -e LOCAL_USER_ID="$(id -u)" \
-    -v "$(pwd):/src" --rm redox make all #4
+    -e LOCAL_UID="$(id -u)" -e LOCAL_GID="$(id -g)" \
+    --device /dev/fuse -v "$(pwd):/home/user/src" --rm redox make update all #4
 make qemu #5
 ```
 To unpack:
@@ -21,7 +23,7 @@ To unpack:
 On selinux systems, replace #4 with:
 ```
 docker run --cap-add MKNOD --cap-add SYS_ADMIN \
-    --device /dev/fuse -e LOCAL_USER_ID="$(id -u)" \
-    -v "$(pwd):/src" --security-opt label=disable \
-    --rm redox make all
+    -e LOCAL_UID="$(id -u)" -e LOCAL_GID="$(id -g)" \
+    --device /dev/fuse -v "$(pwd):/home/user/src" --security-opt label=disable \
+    --rm redox make update all
 ```

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,17 +1,18 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-# Add local user
-# Either use the LOCAL_USER_ID if passed in at runtime or
-# fallback
+# Use -e LOCAL_UID="$(id -u)" -e LOCAL_GID="$(id -g)"
+# on the docker run command line if the container build user is different
+# from the run user
 
-USER_ID=${LOCAL_USER_ID:-9001}
+CONT_UID=`id -u user`
+CONT_GID=`id -g user`
+RUN_UID=${LOCAL_UID:-$CONT_UID}
+RUN_GID=${LOCAL_GID:-$CONT_GID}
 
-echo "Starting with UID : $USER_ID "
-echo "CARGO_HOME is $CARGO_HOME"
-echo "RUSTUP_HOME is $RUSTUP_HOME"
-useradd --shell /bin/bash -u $USER_ID -o -c "" -m user
-export HOME=/home/user
-chown user:user -R $CARGO_HOME
-chown user:user -R $RUSTUP_HOME
+if [ $RUN_UID != $CONT_UID ] || [ $RUN_GID != $CONT_GID ]; then
+    echo -e "\033[01;38;5;155mChanging user id:group to ${RUN_UID}:${RUN_GID}. Please wait...\033[0m"
+    groupmod -g $RUN_GID user
+    usermod -u $RUN_UID -g $RUN_GID user
+fi
 
 exec gosu user:user "$@"


### PR DESCRIPTION
**Problem:** In order to initialize the user with an id matching the host's user id, a `-e LOCAL_USER_ID` argument is passed to the run command. The `entrypoint.sh` script is then in charge of creating the user and changing ownership on `cargo` and `rustup` directories. Finally, `gosu` runs the requested command (`make all`) as `user`.
This strategy allows adapting the container to the environment of the running user. This is needed as we bind `redox` source tree to the container and need read/write access to it. However, every time the container is run, the user creation and `chown -R` are executed.

**Solution:** Pass `--build-arg` to the container build command in order to create the user at container build time. Then, everything can be installed like a local host user would. In order to preserve the ability to adapt the container to the environment of the running user, the host's user id must be checked at run time and the container user id changed when necessary. Take this opportunity to adapt the group id.

**Changes introduced by this pull request:**
- Move user environment creation from `entrypoint.sh` to `Dockerfile`.
- Change user id and group id if necessary.
- `apt-get update` all the repos only once. Update `redox` repo individually.
- Add `user` to the list of `sudoers`.
- Use default user directories for cargo and rust.
- Bind the source tree to the user's `~/src`. Run command uses `/home/user/src/` instead of `/src`. See `README.md`.
- Update `README.md`: update submodule sync step to avoid a dependency on cargo.
- Update `README.md`: use `make update all` to update cargo's environment in the container.

**Constraint**: `x86-64-elf-redox-*` packages use `apt-transport-https`, so `redox.list` must be added after the first `apt-get install`.

**State**: Tested on Fedora 26 only.