### PR TITLE
Skip fuse install on gentoo if already installed

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -281,8 +281,10 @@ gentoo()
 		echo "Installing git..."
 		sudo emerge dev-vcs/git
 	fi
-	echo "Installing fuse..."
-	sudo emerge sys-fs/fuse
+	if [ -z "$(which fusermount)" ]; then
+		echo "Installing fuse..."
+		sudo emerge sys-fs/fuse
+	fi
 	if [ "$2" == "qemu" ]; then
 		if [ -z "$(which qemu-system-x86_64)" ]; then
 			echo "Please install QEMU and re-run this script"


### PR DESCRIPTION
The bootstrap.sh script always installs fuse on gentoo. This small change just checks if it is already installed and skip it if so.