### PR TITLE
Update docker container build script and README

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:17.04
 
-ENV REDOX_TOOLCHAIN_APT http://static.redox-os.org/toolchain/apt/
+ENV REDOX_TOOLCHAIN_APT https://static.redox-os.org/toolchain/apt/
 
 ENV USER user
 ARG LOCAL_UID=local
@@ -9,12 +9,13 @@ ENV BUILD_UID=${LOCAL_UID:-9001}
 ENV BUILD_GID=${LOCAL_GID:-9001}
 
 RUN   apt-get update \
-      && apt-get install -y git gosu gcc fuse nasm qemu-utils pkg-config \
-             libfuse-dev make curl file sudo apt-transport-https autoconf flex \
+      && apt-get install -y dirmngr git gosu gcc fuse nasm qemu-utils pkg-config \
+             libfuse-dev make curl wget file sudo apt-transport-https autoconf flex \
              bison texinfo \
+      && apt-key adv --fetch-keys https://static.redox-os.org/toolchain/apt/keyFile \
       && echo "deb $REDOX_TOOLCHAIN_APT /" >> /etc/apt/sources.list.d/redox.list \
       && apt-get update -o Dir::Etc::sourcelist="redox.list" \
-      && apt-get install -y --force-yes x86-64-elf-redox-newlib x86-64-elf-redox-binutils x86-64-elf-redox-gcc \
+      && apt-get install -y x86-64-unknown-redox-newlib x86-64-unknown-redox-binutils x86-64-unknown-redox-gcc \
       && groupadd -g $BUILD_GID user \
       && useradd --shell /bin/bash -u $BUILD_UID -g $BUILD_GID -o -c "" -m $USER \
       && echo "$USER ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/user-no-sudo-password

--- a/docker/README.md
+++ b/docker/README.md
@@ -4,19 +4,19 @@
 
 ```shell
 git clone https://github.com/redox-os/redox.git ; cd redox #1
-git pull --rebase --recurse-submodules && git submodule sync \
-    && git submodule update --recursive --init #2
 docker build --build-arg LOCAL_UID="$(id -u)" --build-arg LOCAL_GID="$(id -g)" \
-    -t redox docker/ #3
+    -t redox docker/ #2
+git pull --rebase --recurse-submodules && git submodule sync \
+    && git submodule update --recursive --init #3
 docker run --cap-add MKNOD --cap-add SYS_ADMIN \
     -e LOCAL_UID="$(id -u)" -e LOCAL_GID="$(id -g)" \
-    --device /dev/fuse -v "$(pwd):/home/user/src" --rm redox make update all #4
+    --device /dev/fuse -v "$(pwd):/home/user/src" --rm redox make fetch all #4
 make qemu #5
 ```
 To unpack:
 1. Creates a local copy of the repository.
-2. Updates all the submodules in the repository.
-3. Creates a new image in the local image repository named `redox` with Redox toolchain installed. You only need to rebuild the image if you want to update the toolchain.
+2. Creates a new image in the local image repository named `redox` with Redox toolchain installed. You only need to rebuild the image if you want to update the toolchain.
+3. Updates all the submodules in the repository.
 4. Builds Redox using the `redox` image. The arguments allow the container to use `fuse` and ensure the resulting files are owned by the current user.
 5. Runs Redox.
 
@@ -25,5 +25,5 @@ On selinux systems, replace #4 with:
 docker run --cap-add MKNOD --cap-add SYS_ADMIN \
     -e LOCAL_UID="$(id -u)" -e LOCAL_GID="$(id -g)" \
     --device /dev/fuse -v "$(pwd):/home/user/src" --security-opt label=disable \
-    --rm redox make update all
+    --rm redox make fetch all
 ```


### PR DESCRIPTION
- Use https for redox apt repository
- Import the repository's key
- Update [toolchain packages' names](https://github.com/redox-os/cookbook/pull/59)
- Install `wget` which is needed by [coobook/recipes/xz](https://github.com/redox-os/cookbook/blob/master/recipes/xz/recipe.sh)
- Update README file to reflect the [discussion about when the submodules are needed](https://github.com/redox-os/redox/pull/1005#discussion_r129432929)
- Update README file to suggest using `make fetch all` in place of `make update all` since `Cargo.lock` files come with the sources now. See this [comment](https://github.com/redox-os/redox/issues/1021#issuecomment-320946322)

Note: current source tree generation requires runing the docker container with `bash -c RUSTFLAGS=\"-A unused_mut\" make fetch all` in place of `make fetch all`