### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ The ecosystem and software Redox OS provides is listed below.
 
 Sometimes things go wrong when compiling. Try the following before opening an issue:
 
-1. Make sure you have a redox toolchain (`x86_64-elf-redox-gcc`).
+1. Make sure you have a redox toolchain (`x86_64-unknown-redox-gcc`).
     * You can install from .deb packages(`https://static.redox-os.org/toolchain/apt/`) or build [redox-os/libc](https://github.com/redox-os/libc) manually.
 1. Run `rustup update`
 1. Run `make clean pull`.


### PR DESCRIPTION
The toolchain now is called ``x86_64-unknown-redox``.