### PR TITLE
Docker: align APT key retrieval with Cookbook README

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_install:
   sudo add-apt-repository 'deb https://static.redox-os.org/toolchain/apt ./' &&
   sudo apt-get update -qq &&
   sudo apt-get purge -qq binutils-doc &&
-  sudo apt-get install -qq nasm pkg-config fuse libfuse-dev genisoimage syslinux x86-64-elf-redox-gcc &&
+  sudo apt-get install -qq nasm pkg-config fuse libfuse-dev genisoimage syslinux x86-64-unknown-redox-gcc &&
   sudo modprobe fuse &&
   sudo chmod 666 /dev/fuse &&
   sudo chown root:$USER /etc/fuse.conf;

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,5 @@
 FROM ubuntu:17.04
 
-ENV REDOX_TOOLCHAIN_APT https://static.redox-os.org/toolchain/apt/
-
 ENV USER user
 ARG LOCAL_UID=local
 ARG LOCAL_GID=local
@@ -12,8 +10,8 @@ RUN   apt-get update \
       && apt-get install -y dirmngr git gosu gcc fuse nasm qemu-utils pkg-config \
              libfuse-dev make curl wget file sudo apt-transport-https autoconf flex \
              bison texinfo \
-      && apt-key adv --fetch-keys https://static.redox-os.org/toolchain/apt/keyFile \
-      && echo "deb $REDOX_TOOLCHAIN_APT /" >> /etc/apt/sources.list.d/redox.list \
+      && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys AA12E97F0881517F \
+      && echo "deb https://static.redox-os.org/toolchain/apt/ /" >> /etc/apt/sources.list.d/redox.list \
       && apt-get update -o Dir::Etc::sourcelist="redox.list" \
       && apt-get install -y x86-64-unknown-redox-newlib x86-64-unknown-redox-binutils x86-64-unknown-redox-gcc \
       && groupadd -g $BUILD_GID user \


### PR DESCRIPTION
Use the same command as the Cookbook README for Redox OS APT key retrieval.

Keep adding the Redox OS repository in a dedicated file. This allows updating it specifically without updating the other repositories one more time.