### PR TITLE
Disable seccomp and apparmor to compile Redox with Docker image.

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -20,10 +20,17 @@ To unpack:
 4. Builds Redox using the `redox` image. The arguments allow the container to use `fuse` and ensure the resulting files are owned by the current user.
 5. Runs Redox.
 
-On selinux systems, replace #4 with:
+For SELinux, seccomp, and AppArmor enabled systems, please add following commands to #4 accordingly:
+```
+--security-opt label=disable         // disable SELinux
+--security-opt seccomp=unconfined    // disable seccomp
+--security-opt apparmor=unconfined   // disable AppArmor
+```
+
+E.g., on SELinux systems, replace #4 with:
 ```
 docker run --cap-add MKNOD --cap-add SYS_ADMIN \
     -e LOCAL_UID="$(id -u)" -e LOCAL_GID="$(id -g)" \
-    --device /dev/fuse -v "$(pwd):/home/user/src" --security-opt seccomp=unconfined --security-opt apparmor=unconfined \
+    --device /dev/fuse -v "$(pwd):/home/user/src" --security-opt label=disable \
     --rm redox make fetch all
 ```

--- a/docker/README.md
+++ b/docker/README.md
@@ -24,6 +24,6 @@ On selinux systems, replace #4 with:
 ```
 docker run --cap-add MKNOD --cap-add SYS_ADMIN \
     -e LOCAL_UID="$(id -u)" -e LOCAL_GID="$(id -g)" \
-    --device /dev/fuse -v "$(pwd):/home/user/src" --security-opt seccomp=unconfined apparmor=unconfined \
+    --device /dev/fuse -v "$(pwd):/home/user/src" --security-opt seccomp=unconfined --security-opt apparmor=unconfined \
     --rm redox make fetch all
 ```

--- a/docker/README.md
+++ b/docker/README.md
@@ -24,6 +24,6 @@ On selinux systems, replace #4 with:
 ```
 docker run --cap-add MKNOD --cap-add SYS_ADMIN \
     -e LOCAL_UID="$(id -u)" -e LOCAL_GID="$(id -g)" \
-    --device /dev/fuse -v "$(pwd):/home/user/src" --security-opt label=disable \
+    --device /dev/fuse -v "$(pwd):/home/user/src" --security-opt seccomp=unconfined apparmor=unconfined \
     --rm redox make fetch all
 ```


### PR DESCRIPTION
Problem:
Won't compile on machine with apparmor enabled.

Solution:
Disable seccomp and apparmor.

Changes introduced by this pull request:

  - docker/README.md