### PR TITLE
Docker: allow building the container on MacOS and Linux

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,8 +14,12 @@ RUN   apt-get update \
       && echo "deb https://static.redox-os.org/toolchain/apt/ /" >> /etc/apt/sources.list.d/redox.list \
       && apt-get update -o Dir::Etc::sourcelist="redox.list" \
       && apt-get install -y x86-64-unknown-redox-newlib x86-64-unknown-redox-binutils x86-64-unknown-redox-gcc \
-      && groupadd -g $BUILD_GID user \
-      && useradd --shell /bin/bash -u $BUILD_UID -g $BUILD_GID -o -c "" -m $USER \
+      && if [ $BUILD_UID != local ] && [ $BUILD_GID != local ]; then \
+             groupadd -g $BUILD_GID user; \
+             useradd --shell /bin/bash -u $BUILD_UID -g $BUILD_GID -o -c "" -m $USER; \
+         else \
+             useradd --shell /bin/bash -c "" -m $USER; \
+         fi \
       && echo "$USER ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/user-no-sudo-password
 
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh


### PR DESCRIPTION
On MacOS, while building the docker container, `useradd` returns with code 4 (UID already in use), even with option -o. On this platform, the access rights for a volume attached to a running container are translated to the container's user and group. So, there is no need to handle UID and GID compliance like we do on Linux. See this for reference: https://docs.docker.com/docker-for-mac/osxfs/

This modification allows not specifying the UID and GID while building the container, keeping the defaults for `useradd`.

Fixes #1037