### PR TITLE
Add test for '--help' option

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -478,7 +478,7 @@ boot()
 	exit
 }
 
-if [ "$1" == "-h" ]; then
+if [ "$1" == "-h" ] || [ "$1" == "--help" ]; then
 	usage
 elif [ "$1" == "-u" ]; then
 	git pull upstream master


### PR DESCRIPTION
Noticed that full help option was missing, added it.

**Problem**: `--help` did not display help message even though usage output said it should.

**Solution**: Add check for `--help` option
