### PR TITLE
Fix missing build directory

### DIFF
--- a/mk/disk.mk
+++ b/mk/disk.mk
@@ -1,4 +1,5 @@
 build/bootloader: bootloader/$(ARCH)/**
+	mkdir -p build
 	nasm -f bin -o $@ -D ARCH_$(ARCH) -ibootloader/$(ARCH)/ bootloader/$(ARCH)/disk.asm
 
 build/harddrive.bin: build/filesystem.bin bootloader/$(ARCH)/**


### PR DESCRIPTION
Currently, `build/bootloader` is the first make target being executed
during `make all`. However, after a clean checkout, the `build` directory
does not yet exist. Create it accordingly.

```bash
redox@2e39ebdd49f0<redox-os-docker>:/home/arichter/repos/redox$ make
nasm -f bin -o build/bootloader -D ARCH_x86_64 -ibootloader/x86_64/ bootloader/x86_64/disk.asm
nasm: fatal: unable to open output file `build/bootloader'
mk/disk.mk:2: recipe for target 'build/bootloader' failed
make: *** [build/bootloader] Error 1
```