### PR TITLE
Allow specifying a bridge for qemu to use

### DIFF
--- a/mk/qemu.mk
+++ b/mk/qemu.mk
@@ -12,7 +12,11 @@ endif
 ifeq ($(net),no)
 	QEMUFLAGS+=-net none
 else
-	QEMUFLAGS+=-net nic,model=e1000 -net user -net dump,file=build/network.pcap
+	ifneq ($(bridge),)
+		QEMUFLAGS+=-netdev bridge,br=$(bridge),id=net0 -device e1000,netdev=net0,id=nic0
+	else
+		QEMUFLAGS+=-net nic,model=e1000 -net user -net dump,file=build/network.pcap
+	endif
 	ifeq ($(net),redir)
 		QEMUFLAGS+=-redir tcp:8023::8023 -redir tcp:8080::8080
 	endif


### PR DESCRIPTION
**Problem**:

There is no make command to deploy a VM using a bridge.

**Solution**:

Added a conditional in which if `bridge` is populated and `net`
is not `no`, the VM will use the qemu bridge helper to use
the specified bridge. **Note:** The qemu bridge helper
requires that the bridge be in `/etc/qemu/bridge.conf`.

**Changes introduced by this pull request**:

Allow `make qemu` to take an additional parameter `bridge` that
specifies the bridge interface to use for the netdev. This allows
`make qemu brige=br0` which would create a VM connected to br0.
