### PR TITLE
Fix issue #1102: Infinite Recursion with "ls -lR /" in RedoxOS

### DIFF
--- a/filesystem.toml
+++ b/filesystem.toml
@@ -175,32 +175,6 @@ Welcome to Redox OS!
 """
 
 [[files]]
-path = "/usr/bin"
-data = "/bin"
+path = "/usr"
+data = "/"
 symlink = true
-
-[[files]]
-path = "/usr/sbin"
-data = "/sbin"
-symlink = true
-
-[[files]]
-path = "/usr/var"
-data = "/var"
-symlink = true
-
-[[files]]
-path = "/usr/share"
-data = "/share"
-symlink = true
-
-[[files]]
-path = "/usr/include"
-data = "/include"
-symlink = true
-
-[[files]]
-path = "/usr/lib"
-data = "/lib"
-symlink = true
-

--- a/filesystem.toml
+++ b/filesystem.toml
@@ -175,6 +175,32 @@ Welcome to Redox OS!
 """
 
 [[files]]
-path = "/usr"
-data = "/"
+path = "/usr/bin"
+data = "/bin"
 symlink = true
+
+[[files]]
+path = "/usr/sbin"
+data = "/sbin"
+symlink = true
+
+[[files]]
+path = "/usr/var"
+data = "/var"
+symlink = true
+
+[[files]]
+path = "/usr/share"
+data = "/share"
+symlink = true
+
+[[files]]
+path = "/usr/include"
+data = "/include"
+symlink = true
+
+[[files]]
+path = "/usr/lib"
+data = "/lib"
+symlink = true
+

--- a/filesystem.toml
+++ b/filesystem.toml
@@ -175,6 +175,57 @@ Welcome to Redox OS!
 """
 
 [[files]]
-path = "/usr"
-data = "/"
+path = "/usr/filesystem.toml"
+data = "/filesystem.toml"
 symlink = true
+
+[[files]]
+path = "/usr/bin"
+data = "/bin"
+symlink = true
+
+[[files]]
+path = "/usr/bootloader"
+data = "/bootloader"
+symlink = true
+
+[[files]]
+path = "/usr/etc"
+data = "/etc"
+symlink = true
+
+[[files]]
+path = "/usr/home"
+data = "/home"
+symlink = true
+
+[[files]]
+path = "/usr/kernel"
+data = "/kernel"
+symlink = true
+
+[[files]]
+path = "/usr/pkg"
+data = "/pkg"
+symlink = true
+
+[[files]]
+path = "/usr/ref"
+data = "/ref"
+symlink = true
+
+[[files]]
+path = "/usr/root"
+data = "/root"
+symlink = true
+
+[[files]]
+path = "/usr/tmp"
+data = "/tmp"
+symlink = true
+
+[[files]]
+path = "/usr/ui"
+data = "/ui"
+symlink = true
+


### PR DESCRIPTION
**Problem**: see issue #1102 

**Solution**: see solution as described in issue #1102 

**Changes introduced by this pull request**:

- /usr is no longer a soft-link to /, instead, /usr/bin links to /bin etc (same for all folders/files in / corresponding soft-links are created in /usr that link to them) - see #1102 

**Drawbacks**: Any new top-level files/folders added in the future may need corresponding soft-links created in /usr if /usr should always exactly be a mirror of the top-level folder (questionable???)

**TODOs**: nothing that I'm aware of

**Fixes**: see issue #1102 

**State**: READY

**Blocking/related**:  none that I'm aware of

**Other**: (n/a)

