### PR TITLE
Checking that xargo isn't already installed before trying to install …

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -461,7 +461,11 @@ boot()
 	echo "Cloning github repo..."
 	git clone https://github.com/redox-os/redox.git --origin upstream --recursive
 	rustInstall
-	cargo install xargo
+	if [[ "`cargo install --list`" != *"xargo"* ]]; then
+		cargo install xargo
+	else
+		echo "You have xargo installed already!"
+	fi
 	echo "Cleaning up..."
 	rm bootstrap.sh
 	echo


### PR DESCRIPTION
…it - should prevent the bootstrap script erroring out in an ugly way.

**Problem**: [describe the problem you try to solve with this PR.]
The bootstrap script finished with an ugly error when trying to run `cargo install xargo` if xargo was already installed. This didn't seem to actually break anything, but meant the script didn't run the `statusCheck` function, remove the `bootstrap.sh` file or tell the user the commands to run in order to build and run `Redox`.
**Solution**: [describe carefully what you change by this PR.]
I have added a check which uses `cargo install --list` to examine the install crates and check for xargo, only installing it if it isn't present. I hope this will work on any system, but I can only try it on Ubuntu 14.04 and 16.04 at the moment.

**Changes introduced by this pull request**:

**Drawbacks**: [if any, describe the drawbacks of this pull request.]

**TODOs**: [what is not done yet.]

**Fixes**: [what issues this fixes.]

**State**: [the state of this PR, e.g. WIP, ready, etc.]
I think it is ready to merge.
**Blocking/related**: [issues or PRs blocking or being related to this issue.]

**Other**: [optional: for other relevant information that should be known or cannot be described in the other fields.]
This is my first pull request to an OS project - please let me know if I've done anything wrong!