### PR TITLE
Keep debug info in a .sym file

### DIFF
--- a/mk/kernel.mk
+++ b/mk/kernel.mk
@@ -1,9 +1,9 @@
 build/libkernel.a: kernel/Cargo.toml kernel/src/* kernel/src/*/* kernel/src/*/*/* build/initfs.tag
 # Temporary fix for https://github.com/redox-os/redox/issues/963 allowing to build on macOS
 ifeq ($(UNAME),Darwin)
-	cd kernel && CC=$(ARCH)-elf-gcc AR=$(ARCH)-elf-ar CFLAGS=-ffreestanding INITFS_FOLDER=$(ROOT)/build/initfs xargo rustc --lib --target $(KTARGET) --release -- -C soft-float --emit link=../$@
+	cd kernel && CC=$(ARCH)-elf-gcc AR=$(ARCH)-elf-ar CFLAGS=-ffreestanding INITFS_FOLDER=$(ROOT)/build/initfs xargo rustc --lib --target $(KTARGET) --release -- -C soft-float -C debuginfo=2 --emit link=../$@
 else
-	cd kernel && INITFS_FOLDER=$(ROOT)/build/initfs xargo rustc --lib --target $(KTARGET) --release -- -C soft-float --emit link=../$@
+	cd kernel && INITFS_FOLDER=$(ROOT)/build/initfs xargo rustc --lib --target $(KTARGET) --release -- -C soft-float -C debuginfo=2 --emit link=../$@
 endif
 
 build/libkernel_live.a: kernel/Cargo.toml kernel/src/* kernel/src/*/* kernel/src/*/*/* build/initfs_live.tag
@@ -11,6 +11,8 @@ build/libkernel_live.a: kernel/Cargo.toml kernel/src/* kernel/src/*/* kernel/src
 
 build/kernel: kernel/linkers/$(ARCH).ld build/libkernel.a
 	$(LD) --gc-sections -z max-page-size=0x1000 -T $< -o $@ build/libkernel.a
+	objcopy --only-keep-debug $@ $@.sym
+	objcopy --strip-debug $@
 
 build/kernel_live: kernel/linkers/$(ARCH).ld build/libkernel_live.a build/live.o
 	$(LD) --gc-sections -z max-page-size=0x1000 -T $< -o $@ build/libkernel_live.a build/live.o

--- a/mk/qemu.mk
+++ b/mk/qemu.mk
@@ -27,6 +27,9 @@ endif
 ifneq ($(usb),no)
 	QEMUFLAGS+=-device nec-usb-xhci,id=xhci -device usb-tablet,bus=xhci.0
 endif
+ifneq ($(gdb),yes)
+	QEMUFLAGS+=-s
+endif
 ifeq ($(UNAME),Linux)
 	ifneq ($(kvm),no)
 		QEMUFLAGS+=-enable-kvm -cpu host


### PR DESCRIPTION
**Problem**:

When debugging the redox kernel, it is compiled without debug symbols
which makes debugging difficult.

**Solution**:

Compile with debug info and place debug info in separate `.sym` file.

**Changes introduced by this pull request**:
 - Compile time changes
   - Compile libkernel.a with debug info
   - Copy debug info to kernel.sym
   - Strip the kernel of debug symbols
 - Workflow changes
   - Add `debug` option to `make qemu`

**Drawbacks**:

The `kernel.sym` can be large and `libkernel.a` is larger.
`kernel.sym` is typically around 6 MB for me. It might be
a good idea to put this behind a build option.

**Blocking/related**:

 - redox-os/kernel#64

**TODO**:

 - Write up a wiki page on debugging the redox kernel with `qemu`
   and `gdb`

**Try it out**:

To test this out first make sure that the redox-os/kernel#64 kernel is used,
then rebuild the kernel. After rebuilding the kernel, run the VM and use
`make qemu debug=yes`. Now it's time to crack open `gdb`

```
$ rust-gdb ./build/kernel
(gdb) target remote localhost:1234
(gdb) symbol-file ./build/kernel.sym
... other gdb commands
(gdb) continue
```

Go back to your VM and trigger the syscall you're interested in.