### PR TITLE
Remove broken old kernel link

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ The ecosystem and software Redox OS provides is listed below.
 | [TFS (ticki filesystem)](https://github.com/ticki/tfs)                            | [**@ticki**](https://github.com/ticki)
 | [The Redox book](https://github.com/redox-os/book)                          | [**@ticki**](https://github.com/ticki)
 | [userutils](https://github.com/redox-os/userutils)                          | [**@jackpot51**](https://github.com/jackpot51)
-| [The old kernel](https://github.com/redox-os/old)                           | **abandoned**
+| The old kernel                                                              | **abandoned**
 | [ZFS](https://github.com/redox-os/zfs)                                      | **abandoned, superseded by [TFS](https://github.com/ticki/tfs)**
 
 ## <a name="compile-help"> Help! Redox won't compile! </a>


### PR DESCRIPTION
**Problem**:
Doesn't working link to old kernel.

**Solution**:
Replaced link with text.

**Changes introduced by this pull request**:
- Removed old kernel link.

**Drawbacks**:

**Fixes**:
Doesn't working old kernel link.

**State**:
Ready.
