### PR TITLE
Revert "Use bash as shell until #1124 is fixed"

### DIFF
--- a/filesystem.toml
+++ b/filesystem.toml
@@ -10,7 +10,7 @@ prompt = false
 #acid = {}
 #autoconf = {}
 #automake = {}
-bash = {}
+#bash = {}
 #binutils = {}
 #ca-certificates = {}
 #cargo = {}
@@ -75,12 +75,10 @@ uid = 0
 gid = 0
 name = "root"
 home = "/root"
-shell = "/bin/bash"
 
 [users.user]
 # Password is unset
 password = ""
-shell = "/bin/bash"
 
 [[files]]
 path = "/etc/init.d/00_base"


### PR DESCRIPTION
Reverts redox-os/redox#1125 now that #1124 is fixed