### PR TITLE
add autopoint as dependencie for ubuntu

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -185,7 +185,7 @@ ubuntu()
 	echo "Updating system..."
 	sudo "$2" update
 	echo "Installing required packages..."
-	sudo "$2" install build-essential libc6-dev-i386 nasm curl file git libfuse-dev fuse pkg-config cmake
+	sudo "$2" install build-essential libc6-dev-i386 nasm curl file git libfuse-dev fuse pkg-config cmake autopoint
 	if [ "$1" == "qemu" ]; then
 		if [ -z "$(which qemu-system-x86_64)" ]; then
 			echo "Installing QEMU..."


### PR DESCRIPTION
**Problem**: Ubuntu build fails with "./autogen.sh: autopoint: not found" 

**Solution**: add autopoint as dependencie for ubuntu .

**Changes introduced by this pull request**:

- add autopoint as dependencie for ubuntu . 


**Fixes**: [#1131](https://github.com/redox-os/redox/issues/1131)

**State**: ready

**Blocking/related**: see [#1131](https://github.com/redox-os/redox/issues/1131) and [#1132](https://github.com/redox-os/redox/pull/1132) .
