### PR TITLE
Add more required packages to the Ubuntu bootstrap

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -185,7 +185,7 @@ ubuntu()
 	echo "Updating system..."
 	sudo "$2" update
 	echo "Installing required packages..."
-	sudo "$2" install build-essential libc6-dev-i386 nasm curl file git libfuse-dev fuse pkg-config cmake autopoint
+	sudo "$2" install build-essential libc6-dev-i386 nasm curl file git libfuse-dev fuse pkg-config cmake autopoint autoconf libtool m4 syslinux-utils genisoimage
 	if [ "$1" == "qemu" ]; then
 		if [ -z "$(which qemu-system-x86_64)" ]; then
 			echo "Installing QEMU..."


### PR DESCRIPTION
These packages are also required to build the C apps in the cookbook and to generate the live ISO image. Tested with a clean install of Ubuntu Server 16.04.4 and Pop!_OS Intel 62.