### PR TITLE
Add more Ubuntu/Debian reqiured packages

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -185,7 +185,7 @@ ubuntu()
 	echo "Updating system..."
 	sudo "$2" update
 	echo "Installing required packages..."
-	sudo "$2" install build-essential libc6-dev-i386 nasm curl file git libfuse-dev fuse pkg-config cmake autopoint autoconf libtool m4 syslinux-utils genisoimage
+	sudo "$2" install build-essential libc6-dev-i386 nasm curl file git libfuse-dev fuse pkg-config cmake autopoint autoconf libtool m4 syslinux-utils genisoimage flex bison gperf libpng-dev libhtml-parser-perl
 	if [ "$1" == "qemu" ]; then
 		if [ -z "$(which qemu-system-x86_64)" ]; then
 			echo "Installing QEMU..."


### PR DESCRIPTION
**Problem**:

packages: flex, bison, gperf, libpng-dev, and libhtml-parser-perl are all needed to build redox-os on Ubuntu

**Solution**: 

add flex, bison, gperf, libpng-dev, and libhtml-parser-perl to the Ubuntu bootstrap.