### PR TITLE
Update build steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ $ cd path/to/your/projects/folder/
 # Run bootstrap setup
 $ curl -sf https://raw.githubusercontent.com/redox-os/redox/master/bootstrap.sh -o bootstrap.sh && bash -e bootstrap.sh
 
-#Change to project directory
+# Change to project directory
 $ cd redox
 
 # Build Redox
@@ -139,6 +139,7 @@ $ ./bootstrap.sh -d
 
 # Install rustup.rs
 $ curl https://sh.rustup.rs -sSf | sh
+$ source $HOME/.cargo/env
 
 # Install the sysroot manager Xargo
 $ cargo install xargo


### PR DESCRIPTION
After installing rustup the PATH variable needs to be updated for the current shell to be able to use cargo. The installer even warns about this. Possible fix for #1176.