### PR TITLE
Fix for qemu 2.12

### DIFF
--- a/mk/qemu.mk
+++ b/mk/qemu.mk
@@ -15,7 +15,8 @@ else
 	ifneq ($(bridge),)
 		QEMUFLAGS+=-netdev bridge,br=$(bridge),id=net0 -device e1000,netdev=net0,id=nic0
 	else
-		QEMUFLAGS+=-net nic,model=e1000 -net user -net dump,file=build/network.pcap
+		QEMUFLAGS+=-netdev user,id=net0 -device e1000,netdev=net0 \
+					-object filter-dump,id=f1,netdev=net0,file=build/network.pcap
 	endif
 	ifeq ($(net),redir)
 		QEMUFLAGS+=-redir tcp:8023::8023 -redir tcp:8080::8080


### PR DESCRIPTION
They removed -net dump and replaced it with -object filter-dump