### PR TITLE
fix: building redox in Docker results failure w/ Fuse perms

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -32,7 +32,8 @@ RUN set -ex;                                                                   \
     cargo install cargo-config;                                                \
     apt-get autoremove -q -y;                                                  \
     apt-get clean -q -y;                                                       \
-    rm -rf /var/lib/apt/lists/*
+    rm -rf /var/lib/apt/lists/*                                                \
+    sudo chgrp redox /dev/fuse
 
 COPY entrypoint.sh /usr/local/bin/
 COPY .bash_aliases /etc/skel/


### PR DESCRIPTION
- change /dev/fuse group to redox usr

**Problem**: [describe the problem you try to solve with this PR.]

On building redox in Docker, I encountered this error:

```
fusermount: entry for /Users/jordan1/p/redox/build/filesystem not found in /etc/mtab
rm -rf build/filesystem.bin  build/filesystem.bin.partial build/filesystem/
dd if=/dev/zero of=build/filesystem.bin.partial bs=1048576 count=256
256+0 records in
256+0 records out
268435456 bytes (268 MB, 256 MiB) copied, 2.95173 s, 90.9 MB/s
cargo run --manifest-path redoxfs/Cargo.toml --release --bin redoxfs-mkfs build/filesystem.bin.partial
    Finished release [optimized] target(s) in 0.16 secs
     Running `redoxfs/target/release/redoxfs-mkfs build/filesystem.bin.partial`
redoxfs-mkfs: created filesystem on build/filesystem.bin.partial, reserved 0 blocks, size 268 MB, uuid 170dc48d-3f93-4745-b7f1-349eb5cc42f6
mkdir -p build/filesystem/
cargo build --manifest-path redoxfs/Cargo.toml --release --bin redoxfs
    Finished release [optimized] target(s) in 0.14 secs
cargo run --manifest-path redoxfs/Cargo.toml --release --bin redoxfs -- build/filesystem.bin.partial build/filesystem/
    Finished release [optimized] target(s) in 0.14 secs
     Running `redoxfs/target/release/redoxfs build/filesystem.bin.partial build/filesystem/`
redoxfs: opening build/filesystem.bin.partial
redoxfs: opened filesystem on build/filesystem.bin.partial with uuid 170dc48d-3f93-4745-b7f1-349eb5cc42f6
fuse: failed to open /dev/fuse: Permission denied
redoxfs: failed to mount build/filesystem.bin.partial to build/filesystem/: Permission denied (os error 13)
redoxfs: not able to mount path build/filesystem.bin.partial
mk/filesystem.mk:2: recipe for target 'build/filesystem.bin' failed
make: *** [build/filesystem.bin] Error 1
```


**Solution**: [describe carefully what you change by this PR.]
`sudo chgrp redox /dev/fuse`:

Change owner of `/dev/fuse` to `redox` resolves the issue
